### PR TITLE
feat: add config copy option and --no-copy flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ EOF
 - `-p`, `--provider <name>`: override the configured provider
 - `-m`, `--model <id>`: override the configured model
 - `--copy`: copy final answer to clipboard
+- `--no-copy`: disable copy (overrides config)
 - `--debug`: write debug logs to stderr
 - `-h`, `--help`: show help
 - `-v`, `--version`: show version
@@ -95,7 +96,7 @@ Config is loaded from multiple sources. Later sources override earlier ones:
 
 1. **XDG config**: `$XDG_CONFIG_HOME/q/config.toml` or `~/.config/q/config.toml`
 2. **CWD config**: `./config.toml` in current directory
-3. **Environment variables**: `Q_PROVIDER`, `Q_MODEL`
+3. **Environment variables**: `Q_PROVIDER`, `Q_MODEL`, `Q_COPY`
 
 ### Environment Variables
 
@@ -103,6 +104,7 @@ Config is loaded from multiple sources. Later sources override earlier ones:
 |----------|-------------|
 | `Q_PROVIDER` | Override default provider |
 | `Q_MODEL` | Override default model |
+| `Q_COPY` | Override default copy behaviour (true/false) |
 
 ### Env Var Interpolation
 
@@ -119,6 +121,7 @@ Support `${VAR_NAME}` syntax in specific fields for allowlisted variables only:
 [default]
 provider = "anthropic"
 model = "claude-sonnet-4-20250514"
+# copy = true  # Always copy answer to clipboard (override with --no-copy)
 
 [providers.anthropic]
 type = "anthropic"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ echo "how do I restart docker" | q
 | `-p, --provider <name>` | Override the default provider |
 | `-m, --model <id>` | Override the default model |
 | `--copy` | Copy answer to clipboard |
+| `--no-copy` | Disable copy (overrides config) |
 | `-h, --help` | Show help message |
 
 ### Commands
@@ -76,7 +77,7 @@ Config is loaded from (later overrides earlier):
 
 1. `~/.config/q/config.toml`
 2. `./config.toml` (project-specific)
-3. Environment: `Q_PROVIDER`, `Q_MODEL`
+3. Environment: `Q_PROVIDER`, `Q_MODEL`, `Q_COPY`
 
 See [config.example.toml](config.example.toml) for all options.
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -4,11 +4,12 @@
 # Config resolution order (later overrides earlier):
 #   1. XDG config: ~/.config/q/config.toml (or $XDG_CONFIG_HOME/q/config.toml)
 #   2. Project config: ./config.toml in current directory
-#   3. Environment variables: Q_PROVIDER, Q_MODEL
+#   3. Environment variables: Q_PROVIDER, Q_MODEL, Q_COPY
 
 [default]
 provider = "anthropic"
 model = "claude-sonnet-4-20250514"
+# copy = true  # Always copy answer to clipboard (override with --no-copy)
 
 [providers.anthropic]
 type = "anthropic"
@@ -45,3 +46,30 @@ api_key_env = "OPENAI_API_KEY"
 # [providers.ollama]
 # type = "ollama"
 # base_url = "http://localhost:11434"
+
+# Google Gemini
+# [providers.google]
+# type = "google"
+# api_key_env = "GOOGLE_GENERATIVE_AI_API_KEY"
+# # Models: gemini-2.5-pro, gemini-2.5-flash, gemini-2.0-flash
+
+# Groq (ultra-fast inference)
+# [providers.groq]
+# type = "groq"
+# api_key_env = "GROQ_API_KEY"
+# # Models: llama-3.3-70b-versatile, qwen-qwq-32b, deepseek-r1-distill-llama-70b
+
+# Azure OpenAI
+# [providers.azure]
+# type = "azure"
+# resource_name = "my-azure-resource"  # Or use base_url instead
+# api_key_env = "AZURE_API_KEY"
+# api_version = "v1"  # Optional, defaults to v1
+# # Model = deployment name (e.g., "gpt-4o-deployment")
+
+# AWS Bedrock
+# [providers.bedrock]
+# type = "bedrock"
+# region = "us-east-1"  # Optional, defaults to AWS_REGION env var
+# # Uses standard AWS env vars: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+# # Models: anthropic.claude-3-5-sonnet-20241022-v2:0, us.amazon.nova-pro-v1:0

--- a/src/args.ts
+++ b/src/args.ts
@@ -13,6 +13,7 @@ export interface ParsedArgs {
     provider?: string;
     model?: string;
     copy: boolean;
+    noCopy: boolean;
     debug: boolean;
     help: boolean;
     version: boolean;
@@ -31,6 +32,7 @@ OPTIONS:
   -p, --provider <name>        Override the default provider
   -m, --model <id>             Override the default model
   --copy                       Copy answer to clipboard
+  --no-copy                    Disable copy (overrides config)
   --debug                      Enable debug logging to stderr
   -h, --help                   Show this help message
   -v, --version                Show version
@@ -38,12 +40,13 @@ OPTIONS:
 ENVIRONMENT:
   Q_PROVIDER                   Override default provider
   Q_MODEL                      Override default model
+  Q_COPY                       Override default copy behaviour (true/false)
 
 CONFIG:
   Config is loaded from (in order, later overrides earlier):
     1. ~/.config/q/config.toml (or $XDG_CONFIG_HOME/q/config.toml)
     2. ./config.toml (current directory)
-    3. Environment variables (Q_PROVIDER, Q_MODEL)
+    3. Environment variables (Q_PROVIDER, Q_MODEL, Q_COPY)
 
 EXAMPLES:
   q how do I restart docker
@@ -60,6 +63,7 @@ export function parseCliArgs(argv: string[] = Bun.argv.slice(2)): ParsedArgs {
       provider: { type: "string", short: "p" },
       model: { type: "string", short: "m" },
       copy: { type: "boolean", default: false },
+      "no-copy": { type: "boolean", default: false },
       debug: { type: "boolean", default: false },
       help: { type: "boolean", short: "h", default: false },
       version: { type: "boolean", short: "v", default: false },
@@ -72,6 +76,7 @@ export function parseCliArgs(argv: string[] = Bun.argv.slice(2)): ParsedArgs {
     provider: values.provider,
     model: values.model,
     copy: values.copy ?? false,
+    noCopy: values["no-copy"] ?? false,
     debug: values.debug ?? false,
     help: values.help ?? false,
     version: values.version ?? false,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,7 +103,11 @@ async function main(): Promise<void> {
     });
 
     // Copy to clipboard if requested
-    if (args.options.copy) {
+    // Resolution: --no-copy > --copy > Q_COPY env > config.default.copy > false
+    const shouldCopy =
+      !args.options.noCopy && (args.options.copy || config.default.copy);
+
+    if (shouldCopy) {
       await clipboard.write(result.text);
       logDebug("Copied to clipboard", debug);
     }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -42,6 +42,7 @@ export type ProviderConfig = z.infer<typeof ProviderConfigSchema>;
 export const DefaultConfigSchema = z.object({
   provider: z.string(),
   model: z.string(),
+  copy: z.boolean().optional(),
 });
 export type DefaultConfig = z.infer<typeof DefaultConfigSchema>;
 
@@ -88,7 +89,7 @@ export function getConfigDir(): string {
 }
 
 export class Config {
-  readonly default: { provider: string; model: string };
+  readonly default: { provider: string; model: string; copy?: boolean };
   readonly providers: Record<string, ProviderConfig>;
 
   private constructor(data: ConfigData) {
@@ -117,6 +118,7 @@ export class Config {
       ...mergedDefault,
       ...(env.Q_PROVIDER ? { provider: env.Q_PROVIDER } : {}),
       ...(env.Q_MODEL ? { model: env.Q_MODEL } : {}),
+      ...(env.Q_COPY !== undefined ? { copy: env.Q_COPY } : {}),
     };
 
     const merged = {
@@ -278,11 +280,12 @@ export const EXAMPLE_CONFIG = `# q configuration file
 # Config resolution order (later overrides earlier):
 #   1. This file (XDG_CONFIG_HOME/q/config.toml or ~/.config/q/config.toml)
 #   2. ./config.toml in current directory (project-specific)
-#   3. Environment variables: Q_PROVIDER, Q_MODEL
+#   3. Environment variables: Q_PROVIDER, Q_MODEL, Q_COPY
 
 [default]
 provider = "anthropic"
 model = "claude-sonnet-4-20250514"
+# copy = true  # Always copy answer to clipboard (override with --no-copy)
 
 [providers.anthropic]
 type = "anthropic"

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,10 +1,24 @@
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 
+const booleanString = z
+  .string()
+  .optional()
+  .transform((val) => {
+    if (val === undefined) return undefined;
+    const lower = val.toLowerCase();
+    if (lower === "true" || lower === "1") return true;
+    if (lower === "false" || lower === "0") return false;
+    throw new Error(
+      `Invalid Q_COPY value: '${val}'. Use 'true', 'false', '1', or '0'.`,
+    );
+  });
+
 export const env = createEnv({
   server: {
     Q_PROVIDER: z.string().optional(),
     Q_MODEL: z.string().optional(),
+    Q_COPY: booleanString,
   },
   runtimeEnv: process.env,
   emptyStringAsUndefined: true,

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -30,6 +30,19 @@ describe("CLI argument parsing", () => {
     it("should parse --copy flag", () => {
       const args = parseCliArgs(["--copy", "test"]);
       expect(args.options.copy).toBe(true);
+      expect(args.options.noCopy).toBe(false);
+    });
+
+    it("should parse --no-copy flag", () => {
+      const args = parseCliArgs(["--no-copy", "test"]);
+      expect(args.options.noCopy).toBe(true);
+      expect(args.options.copy).toBe(false);
+    });
+
+    it("should parse both --copy and --no-copy flags", () => {
+      const args = parseCliArgs(["--copy", "--no-copy", "test"]);
+      expect(args.options.copy).toBe(true);
+      expect(args.options.noCopy).toBe(true);
     });
 
     it("should parse --debug flag", () => {
@@ -113,6 +126,8 @@ describe("CLI argument parsing", () => {
       expect(help).toContain("--provider");
       expect(help).toContain("--model");
       expect(help).toContain("--copy");
+      expect(help).toContain("--no-copy");
+      expect(help).toContain("Q_COPY");
     });
   });
 

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -86,6 +86,68 @@ describe("config schema", () => {
       expect(result.success).toBe(true);
     });
 
+    it("should validate config with copy option", () => {
+      const config = {
+        default: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-20250514",
+          copy: true,
+        },
+        providers: {
+          anthropic: {
+            type: "anthropic",
+            api_key_env: "ANTHROPIC_API_KEY",
+          },
+        },
+      };
+      const result = ConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.default.copy).toBe(true);
+      }
+    });
+
+    it("should allow copy to be false", () => {
+      const config = {
+        default: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-20250514",
+          copy: false,
+        },
+        providers: {
+          anthropic: {
+            type: "anthropic",
+            api_key_env: "ANTHROPIC_API_KEY",
+          },
+        },
+      };
+      const result = ConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.default.copy).toBe(false);
+      }
+    });
+
+    it("should allow copy to be omitted (optional)", () => {
+      const config = {
+        default: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-20250514",
+        },
+        providers: {
+          anthropic: {
+            type: "anthropic",
+            api_key_env: "ANTHROPIC_API_KEY",
+          },
+        },
+      };
+      const result = ConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.default.copy).toBeUndefined();
+      }
+    });
+
     it("should reject config without default section", () => {
       const config = {
         providers: {


### PR DESCRIPTION
## Summary

- Add `copy` option to `[default]` config section for always-on clipboard behaviour
- Add `Q_COPY` environment variable override (accepts `true`/`false`/`1`/`0`)
- Add `--no-copy` CLI flag to disable copy when enabled by default
- Add provider examples (Google, Groq, Azure, Bedrock) to `config.example.toml`

## Resolution Order

```
--no-copy > --copy > Q_COPY env > config.default.copy > false
```

## Usage

**Config file:**
```toml
[default]
provider = "anthropic"
model = "claude-sonnet-4-20250514"
copy = true  # Always copy answer to clipboard
```

**Environment variable:**
```bash
export Q_COPY=true
q "how do I restart docker"
```

**CLI override:**
```bash
# Disable copy even when config has copy = true
q --no-copy "how do I restart docker"
```

## Testing

- All 101 tests pass
- Biome lint passes
- Added tests for `--no-copy` flag parsing
- Added schema tests for `copy` option (true/false/omitted)
