### PR TITLE
🛡️ Sentinel: [HIGH] Fix pastejacking vulnerability via clipboard output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The AI model's output was written directly to stdout without sanitization, allowing malicious models or prompt injections to inject ANSI escape codes that could manipulate the user's terminal (e.g., hiding text, changing colors, or potentially executing commands in vulnerable terminals).
 **Learning:** Output from LLMs is untrusted user input, even if it comes from a "trusted" provider. It must be sanitized before being displayed in a terminal.
 **Prevention:** Strip ANSI escape codes from all AI-generated output before writing to stdout.
+
+## 2025-03-02 - Pastejacking via Clipboard Output
+**Vulnerability:** The AI model's output was written directly to the user's clipboard without escaping C0 control characters (like Null, Bell, or Backspace), allowing a malicious model or prompt injection to hide text or manipulate the clipboard payload when pasted into a terminal.
+**Learning:** Text copied to the clipboard may eventually be pasted into a shell or text editor. Raw terminal control sequences can be harmful if not escaped properly.
+**Prevention:** Sanitize text before writing it to the clipboard by stripping ANSI codes and escaping dangerous C0 control characters (e.g., `\xNN`), while preserving safe whitespace like line feeds (`\x0A`), tabs (`\x09`), and carriage returns (`\x0D`).

--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -22,6 +22,28 @@ export function stripAnsi(str: string): string {
 }
 
 /**
+ * Sanitizes output for clipboard copying to prevent Pastejacking.
+ * Strips ANSI codes and escapes dangerous C0 control characters
+ * while preserving safe whitespace like line feeds and tabs.
+ */
+export function sanitizeForClipboard(text: string): string {
+  if (!text) return text;
+
+  // First strip any ANSI escape codes
+  const stripped = stripAnsi(text);
+
+  // Replace dangerous C0 control characters and DEL with hex equivalents
+  // Safe whitespace: \x09 (Tab), \x0A (LF), \x0D (CR) are NOT matched by this regex
+  return stripped.replace(
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching C0 control characters to escape them
+    /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g,
+    (char) => {
+      return `\\x${char.charCodeAt(0).toString(16).padStart(2, "0").toUpperCase()}`;
+    },
+  );
+}
+
+/**
  * Creates a stateful ANSI stripper that handles split chunks.
  */
 export function createAnsiStripper() {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import { sanitizeForClipboard } from "./ansi.ts";
 import { getHelpText, getVersion, parseCliArgs } from "./args.ts";
 import { getConfigPath, initConfig, loadConfig } from "./config/index.ts";
 import { formatEnvForDebug, getEnvironmentInfo } from "./env-info.ts";
@@ -108,7 +109,8 @@ async function main(): Promise<void> {
 
     if (shouldCopy) {
       const { default: clipboard } = await import("clipboardy");
-      await clipboard.write(result.text);
+      const safeText = sanitizeForClipboard(result.text);
+      await clipboard.write(safeText);
       logDebug("Copied to clipboard", debug);
     }
 

--- a/tests/ansi_security.test.ts
+++ b/tests/ansi_security.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { sanitizeForClipboard } from "../src/ansi.ts";
 import * as run from "../src/run.ts";
 
 // Mock 'ai' module
@@ -73,5 +74,46 @@ describe("runQuery Security", () => {
 
     // return value should have codes
     expect(result.text).toBe("Start\u001b[31mRed\u001b[0m");
+  });
+});
+
+describe("sanitizeForClipboard Security", () => {
+  test("strips ANSI codes and escapes C0 control characters", () => {
+    // Input containing ANSI colors, a safe LF, a safe Tab, a safe CR,
+    // and dangerous C0 codes: Null (\x00), Bell (\x07), Backspace (\x08), DEL (\x7F)
+    const maliciousInput =
+      "Hello\u001b[31mWorld\u001b[0m\n\t\r\u0000\u0007\u0008\u007F";
+    const sanitized = sanitizeForClipboard(maliciousInput);
+
+    // ANSI codes should be stripped
+    expect(sanitized).not.toContain("\u001b[31m");
+    expect(sanitized).not.toContain("\u001b[0m");
+
+    // "HelloWorld" text should be present
+    expect(sanitized).toContain("HelloWorld");
+
+    // Safe whitespace should be preserved
+    expect(sanitized).toContain("\n");
+    expect(sanitized).toContain("\t");
+    expect(sanitized).toContain("\r");
+
+    // Dangerous control characters should be escaped to hex (\xNN)
+    expect(sanitized).toContain("\\x00");
+    expect(sanitized).toContain("\\x07");
+    expect(sanitized).toContain("\\x08");
+    expect(sanitized).toContain("\\x7F");
+
+    // Ensure raw C0 characters are completely gone
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching C0 control characters to test them
+    expect(sanitized).not.toMatch(/[\x00\x07\x08\x7F]/);
+
+    // Exact expected output
+    expect(sanitized).toBe("HelloWorld\n\t\r\\x00\\x07\\x08\\x7F");
+  });
+
+  test("handles empty and plain text correctly", () => {
+    expect(sanitizeForClipboard("")).toBe("");
+    expect(sanitizeForClipboard("Normal text")).toBe("Normal text");
+    expect(sanitizeForClipboard("Multiline\nText")).toBe("Multiline\nText");
   });
 });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The AI model's output was written directly to the user's clipboard without escaping C0 control characters (like Null, Bell, or Backspace), allowing a malicious model or prompt injection to hide text or manipulate the clipboard payload when pasted into a terminal (Pastejacking).
🎯 Impact: A user piping untrusted code into the CLI and using the `--copy` flag could unintentionally copy terminal manipulation payloads. When pasting this payload into a terminal or text editor, it could obfuscate malicious commands or execute them.
🔧 Fix: Implemented a `sanitizeForClipboard` utility in `src/ansi.ts` that strips ANSI escape codes and replaces dangerous C0 control characters and DEL (`[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]`) with their harmless hex string representations (`\xNN`), while correctly preserving safe whitespace (`\n`, `\t`, `\r`).
✅ Verification: Ran `bun run test` on the new unit tests added to `tests/ansi_security.test.ts`. Verified the CLI output sanitization correctly runs before `clipboardy.write`. Verified code correctly lints with `bun run lint`.

---
*PR created automatically by Jules for task [2842956307667431155](https://jules.google.com/task/2842956307667431155) started by @hongymagic*