### PR TITLE
chore(deps): add automated dependency update workflows

### DIFF
--- a/.github/workflows/deps-update-copilot.yml
+++ b/.github/workflows/deps-update-copilot.yml
@@ -1,0 +1,49 @@
+name: Update Dependencies (Copilot)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  create-issue:
+    name: Create Update Issue for Copilot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create issue and assign Copilot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat <<'BODY' > /tmp/issue-body.md
+          ## Task
+
+          Update all dependencies to their latest versions.
+
+          ### Steps
+
+          1. Run `npx npm-check-updates -u` to update version ranges in `package.json`
+          2. Run `bun install` to regenerate `bun.lock`
+          3. Commit both `package.json` and `bun.lock`
+
+          ### Constraints
+
+          - This project uses **Bun** as its package manager
+          - The lockfile is `bun.lock`
+          - Do NOT modify any source code — only `package.json` and `bun.lock`
+          - Do NOT run tests (CI handles that on the PR)
+          - Commit message: `chore(deps): automated dependency update`
+          BODY
+
+          ISSUE_URL=$(gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "chore(deps): automated dependency update $(date -u +%Y-%m-%d)" \
+            --body-file /tmp/issue-body.md)
+
+          ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+          echo "Created issue #${ISSUE_NUMBER}: ${ISSUE_URL}"
+
+          gh issue edit "$ISSUE_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --add-assignee copilot

--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -1,0 +1,50 @@
+name: Update Dependencies
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Daily at 00:00 UTC (10:00 AEST)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    name: Update Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Update package versions
+        run: npx npm-check-updates -u
+
+      - name: Install updated dependencies
+        run: bun install
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          # NOTE: PRs created with the default GITHUB_TOKEN won't trigger CI
+          # workflows (GitHub's infinite-loop prevention). To auto-trigger CI,
+          # create a PAT with 'repo' scope stored as a secret, then use:
+          #   token: ${{ secrets.PAT_TOKEN }}
+          commit-message: "chore(deps): automated dependency update"
+          title: "chore(deps): automated dependency update"
+          body: |
+            Automated dependency update via `npm-check-updates`.
+
+            ### What changed
+            - `package.json` version bumps (all dependencies, including major)
+            - `bun.lock` regenerated
+
+            ### Review checklist
+            - [ ] CI passes (lint, typecheck, test)
+            - [ ] No unexpected breaking changes
+          branch: deps/automated-update
+          delete-branch: true
+          labels: dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,6 +371,28 @@ This allows GitHub Actions to publish without storing npm tokens as secrets.
 
 ---
 
+## Dependency Updates
+
+Automated dependency updates are handled by two GitHub Actions workflows.
+
+### Custom Action (`deps-update.yml`)
+
+- **Schedule**: Daily at 00:00 UTC (10:00 AEST)
+- **Manual trigger**: `workflow_dispatch` via GitHub Actions UI
+- **Mechanism**: Runs `npx npm-check-updates -u` then `bun install`
+- **Output**: Creates/updates a PR on branch `deps/automated-update`
+- **CI**: Existing `ci.yml` validates the PR (lint, typecheck, test)
+- **Behaviour**: Skips PR creation if no packages changed; updates existing PR if one is already open
+
+### Copilot Agent (`deps-update-copilot.yml`)
+
+- **Manual trigger only**: `workflow_dispatch` via GitHub Actions UI
+- **Mechanism**: Creates a GitHub issue with update instructions, assigns `@copilot`
+- **Prerequisite**: Copilot Coding Agent must be enabled in repo settings (Settings > Copilot > Coding agent)
+- **Output**: Copilot creates a PR from the issue
+
+---
+
 ## Tests
 
 Use vitest (not Bun's test runner).


### PR DESCRIPTION
## Summary

- Add **`deps-update.yml`** — custom GitHub Action that runs `ncu -u` + `bun install` daily at 00:00 UTC, creates/updates a PR on `deps/automated-update` via `peter-evans/create-pull-request`
- Add **`deps-update-copilot.yml`** — experimental workflow (manual trigger only) that creates an issue and assigns GitHub Copilot coding agent to perform the update
- Update **`AGENTS.md`** with documentation for both workflows

## Details

### Custom Action (`deps-update.yml`)

| | |
|---|---|
| **Schedule** | Daily at 00:00 UTC (10:00 AEST) |
| **Manual trigger** | `workflow_dispatch` |
| **Mechanism** | `npx npm-check-updates -u` then `bun install` |
| **PR branch** | `deps/automated-update` |
| **CI validation** | Existing `ci.yml` runs on the PR |
| **Idempotent** | Skips if no changes; updates existing PR if open |

### Copilot Agent (`deps-update-copilot.yml`)

| | |
|---|---|
| **Trigger** | Manual only (`workflow_dispatch`) |
| **Mechanism** | Creates issue with update instructions, assigns `@copilot` |
| **Prerequisite** | Copilot Coding Agent enabled in repo settings |

### Known limitation

PRs created with the default `GITHUB_TOKEN` won't auto-trigger CI workflows (GitHub's infinite-loop prevention). A comment in the workflow explains how to use a PAT to work around this.