### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Secret Leakage in Debug Logs via Nested Config Properties

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,8 @@
 **Vulnerability:** The AI model's output was copied to the clipboard without full sanitization. While ANSI codes are visible in standard text editors, dangerous C0 control characters (like Null `\x00`, Backspace `\x08`, or Escape `\x1B` without sequences) and the DEL character (`\x7F`) might be silently executed or interpreted when pasted into a terminal or text editor, leading to unintended command execution.
 **Learning:** Output destined for the clipboard needs stricter sanitization than output destined for stdout, as the context of pasting is unknown and potentially dangerous.
 **Prevention:** Implement a dedicated clipboard sanitizer that not only strips ANSI escape codes but also replaces dangerous, non-printable control characters with their hex representation, while preserving safe whitespace.
+
+## 2025-02-18 - Secret Leakage in Debug Logs via Nested Config Properties
+**Vulnerability:** The `filterSensitiveFields` function properly filtered top-level sensitive keys but failed to recursively redact fields, meaning nested objects (like `headers` which may contain `Authorization` or `x-api-key`) were logged in plaintext in debug mode.
+**Learning:** Log sanitization functions must recursively inspect properties, especially in complex objects like request headers where standard sensitive tokens are frequently sent.
+**Prevention:** Implement a recursive key checker in log redaction/filtering functions that handles nested structures properly.

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -30,22 +30,35 @@ const SENSITIVE_FIELD_PATTERNS = [
   "credential",
 ];
 
+function isSensitiveKey(key: string): boolean {
+  const lowerKey = key.toLowerCase();
+  return SENSITIVE_FIELD_PATTERNS.some((pattern) => lowerKey.includes(pattern));
+}
+
 /**
  * Filter sensitive fields from a provider config for safe logging.
- * Removes any field containing: key, secret, token, password, auth, credential
+ * Removes any field containing: key, secret, token, password, auth, credential.
+ * Also recursively filters nested objects like headers.
  * @internal Exported for testing only
  */
 export function filterSensitiveFields(
-  config: ProviderConfig,
+  config: Record<string, unknown>,
 ): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(config).filter(([key]) => {
-      const lowerKey = key.toLowerCase();
-      return !SENSITIVE_FIELD_PATTERNS.some((pattern) =>
-        lowerKey.includes(pattern),
-      );
-    }),
-  );
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(config)) {
+    if (isSensitiveKey(key)) {
+      continue;
+    }
+
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      result[key] = filterSensitiveFields(value as Record<string, unknown>);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
 }
 
 /**

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -153,6 +153,33 @@ describe("security", () => {
       expect(filtered).not.toHaveProperty("API_KEY_ENV");
       expect(filtered).not.toHaveProperty("SECRET_VALUE");
     });
+
+    it("should recursively filter sensitive fields in nested objects like headers", () => {
+      const testConfig = {
+        type: "openai_compatible" as const,
+        base_url: "https://api.example.com",
+        headers: {
+          Authorization: "Bearer secret-token",
+          "x-api-key": "secret-key",
+          "Content-Type": "application/json",
+          "x-custom-header": "safe-value",
+        },
+      };
+
+      const filtered = filterSensitiveFields(
+        testConfig as unknown as Parameters<typeof filterSensitiveFields>[0],
+      );
+
+      expect(filtered).toHaveProperty("type");
+      expect(filtered).toHaveProperty("base_url");
+      expect(filtered).toHaveProperty("headers");
+
+      const filteredHeaders = filtered.headers as Record<string, string>;
+      expect(filteredHeaders).toHaveProperty("Content-Type");
+      expect(filteredHeaders).toHaveProperty("x-custom-header");
+      expect(filteredHeaders).not.toHaveProperty("Authorization");
+      expect(filteredHeaders).not.toHaveProperty("x-api-key");
+    });
   });
 
   describe("CLI argument safety", () => {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `filterSensitiveFields` function correctly redacted top-level fields like `api_key_env` but didn't recursively redact fields. Consequently, nested objects like `headers` could expose sensitive tokens (e.g. `Authorization` or `x-api-key`) in plaintext when running in debug mode (`--debug`).
🎯 Impact: An attacker or user running in debug mode could inadvertently leak API credentials to standard output or log aggregators, compromising their configured provider accounts.
🔧 Fix: Updated `filterSensitiveFields` to recursively walk through objects (like the `headers` property) and apply the `SENSITIVE_FIELD_PATTERNS` mask.
✅ Verification: Created a dedicated test in `tests/security.test.ts` to assert that sensitive nested keys are appropriately removed while safe ones remain. Also updated the `.jules/sentinel.md` journal with this learning. All tests pass with `bun run test`.

---
*PR created automatically by Jules for task [7416215240448475308](https://jules.google.com/task/7416215240448475308) started by @hongymagic*