### PR TITLE
🛡️ Sentinel: [HIGH] Fix secret leakage in Portkey provider debug logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -24,3 +24,8 @@
 **Vulnerability:** The `filterSensitiveFields` function properly filtered top-level sensitive keys but failed to recursively redact fields, meaning nested objects (like `headers` which may contain `Authorization` or `x-api-key`) were logged in plaintext in debug mode.
 **Learning:** Log sanitization functions must recursively inspect properties, especially in complex objects like request headers where standard sensitive tokens are frequently sent.
 **Prevention:** Implement a recursive key checker in log redaction/filtering functions that handles nested structures properly.
+
+## 2026-03-06 - Secret Leakage in Portkey Provider Debug Logs
+**Vulnerability:** In `src/providers/portkey.ts`, the logging code meant to mask sensitive headers (like `Authorization` or `x-portkey-api-key`) was flawed. If a sensitive value was 12 characters or less, it was completely exposed in plain text in the debug logs instead of being masked.
+**Learning:** Conditional masking logic often fails to account for shorter strings or edge cases in lengths. When using a ternary that checks for length, ensure the alternate case for a shorter length securely masks the string rather than falling through to the unmasked original value.
+**Prevention:** Fully mask short strings (e.g., using `"********"`) and verify boundary conditions for all sensitive data redaction functions.

--- a/src/providers/portkey.ts
+++ b/src/providers/portkey.ts
@@ -60,10 +60,11 @@ export function createPortkeyProvider(
     const isSensitive =
       key.toLowerCase().includes("key") ||
       key.toLowerCase() === "authorization";
-    const maskedValue =
-      isSensitive && value.length > 12
+    const maskedValue = isSensitive
+      ? value.length > 12
         ? `${value.substring(0, 8)}...${value.substring(value.length - 4)}`
-        : value;
+        : "********"
+      : value;
     logDebug(`  ${key}: ${maskedValue}`, debug);
   }
 


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:**
In `src/providers/portkey.ts`, the logging code meant to mask sensitive headers (like `Authorization` or `x-portkey-api-key`) was flawed. If a sensitive value was 12 characters or less, it was completely exposed in plain text in the debug logs instead of being masked.

🎯 **Impact:**
Short secrets or API keys could have been leaked into application logs and exposed if the user ran the command in debug mode (`--debug`). While the threshold of 12 makes it rare for very long keys, shorter tokens could have been compromised.

🔧 **Fix:**
Updated the `maskedValue` logic to explicitly return `"********"` when the string is sensitive and 12 characters or shorter.

✅ **Verification:**
- Ran the test suite to verify code functionality (`bun run test`).
- Ran `bun run lint` to ensure code styles are kept.

---
*PR created automatically by Jules for task [10039226565394697001](https://jules.google.com/task/10039226565394697001) started by @hongymagic*