### PR TITLE
fix(cli): improve failure handling and terminal feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,9 @@ q providers                 # List configured providers + default
 ### I/O contract
 
 - **stdout**: answer text (streamed)
-- **stderr**: logs, warnings, errors
+- **stderr**: TTY loading indicator, logs, warnings, concise errors, and debug output
+- **failure logs**: non-usage failures write a detailed log file to the platform log directory and print `Full log: <path>` on stderr
+- **interactive recovery**: when stdin/stdout/stderr are TTYs, query failures offer `r` to retry, `Enter` to view the full log, and `q`/`Esc` to exit
 
 ---
 
@@ -186,6 +188,9 @@ src/
 ├── args.ts             # CLI argument parsing (util.parseArgs)
 ├── env.ts              # Type-safe env vars (@t3-oss/env-core)
 ├── env-info.ts         # Environment detection (OS, shell, terminal)
+├── failure-prompt.ts   # Interactive retry/view-log prompt for TTY failures
+├── loading-indicator.ts # TTY loading spinner while waiting for first output
+├── logging.ts          # stderr logging + failure log writer
 ├── stdin.ts            # Stdin/pipe input handling
 ├── config/
 │   └── index.ts        # Config class, schemas, paths (consolidated)
@@ -250,6 +255,8 @@ scripts/
 | `@ai-sdk/amazon-bedrock` | AWS Bedrock provider |
 | `zod` | Schema validation (v4) |
 | `clipboardy` | Clipboard support |
+| `env-paths` | Cross-platform log directory resolution |
+| `picocolors` | Lightweight stderr colour formatting |
 | `@t3-oss/env-core` | Type-safe env vars |
 | `vitest` | Test runner (dev) |
 | `@vitest/coverage-v8` | V8 code coverage reporter (dev) |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 A fast, minimal CLI for getting AI answers directly in your terminal.
 
+When running in an interactive terminal, `q` shows a small ASCII loading indicator on stderr while it waits for the first response text.
+
 ## Installation
 
 ```bash
@@ -151,9 +153,15 @@ export ANTHROPIC_API_KEY="your-key-here"
 
 Run `q config init` to create a default configuration file.
 
+**Failure logs:**
+
+Most non-usage failures print a short error plus `Full log: <path>` on stderr. Logs are written to your platform log directory, for example `~/.local/state/q/errors` on Linux.
+
+In an interactive terminal, query failures also offer quick recovery options: press `r` to retry, `Enter` to print the full log, or `q`/`Esc` to exit.
+
 **Debug mode:**
 
-Use `--debug` to see detailed logs on stderr:
+Use `--debug` to keep detailed diagnostics on stderr while still writing the full failure log:
 
 ```bash
 q --debug "how do I list docker containers"

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,9 @@
         "@t3-oss/env-core": "0.13.10",
         "ai": "6.0.116",
         "clipboardy": "5.3.1",
+        "env-paths": "4.0.0",
         "ollama-ai-provider-v2": "3.3.1",
+        "picocolors": "1.1.1",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -261,6 +263,8 @@
 
     "crypto-random-string": ["crypto-random-string@4.0.0", "", { "dependencies": { "type-fest": "^1.0.1" } }, "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA=="],
 
+    "env-paths": ["env-paths@4.0.0", "", { "dependencies": { "is-safe-filename": "^0.1.0" } }, "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw=="],
+
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
@@ -294,6 +298,8 @@
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-safe-filename": ["is-safe-filename@0.1.1", "", {}, "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g=="],
 
     "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
     "@t3-oss/env-core": "0.13.10",
     "ai": "6.0.116",
     "clipboardy": "5.3.1",
+    "env-paths": "4.0.0",
     "ollama-ai-provider-v2": "3.3.1",
+    "picocolors": "1.1.1",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,32 @@
 #!/usr/bin/env bun
+import type { ParsedArgs } from "./args.ts";
 import { getHelpText, getVersion, parseCliArgs } from "./args.ts";
 import { getConfigPath, initConfig, loadConfig } from "./config/index.ts";
 import { formatEnvForDebug, getEnvironmentInfo } from "./env-info.ts";
-import { logDebug, logError, QError, UsageError } from "./errors.ts";
+import {
+  getUserErrorMessage,
+  QError,
+  shouldWriteFailureLog,
+  UsageError,
+} from "./errors.ts";
+import {
+  canPromptForFailureRecovery,
+  promptForFailureRecovery,
+} from "./failure-prompt.ts";
+import { startLoadingIndicator } from "./loading-indicator.ts";
+import {
+  configureLogging,
+  formatErrorDiagnostics,
+  logDebug,
+  logError,
+  printStderr,
+  updateLogContext,
+  writeFailureLog,
+} from "./logging.ts";
 import { buildSystemPrompt } from "./prompt.ts";
 import { listProviders, resolveProvider } from "./providers/index.ts";
 import { runQuery } from "./run.ts";
+import type { StdinInput } from "./stdin.ts";
 import {
   MAX_CONTEXT_LENGTH,
   MAX_QUERY_LENGTH,
@@ -19,6 +40,8 @@ async function main(): Promise<void> {
   try {
     const args = parseCliArgs();
     debug = args.options.debug;
+    configureLogging({ debug });
+    updateLogContext({ command: args.command, configPath: getConfigPath() });
 
     // Handle --version (before stdin to avoid blocking)
     if (args.options.version) {
@@ -56,49 +79,106 @@ async function main(): Promise<void> {
       process.exit(0);
     }
 
-    // Resolve input mode and extract query/context
-    const { mode, query, context } = resolveInput(stdinInput, args.query);
-    logDebug(`Mode: ${mode}`, debug);
+    let attempt = 0;
 
-    // Security: Limit query length to prevent abuse and excessive API costs
-    if (query.length > MAX_QUERY_LENGTH) {
-      throw new UsageError(
-        `Query too long (${query.length} characters). Maximum is ${MAX_QUERY_LENGTH}.`,
-      );
+    while (true) {
+      attempt += 1;
+      configureLogging({ debug });
+      updateLogContext({
+        attempt,
+        command: args.command,
+        configPath: getConfigPath(),
+      });
+
+      try {
+        await runQueryAttempt(args, stdinInput, debug);
+        process.exit(0);
+      } catch (err) {
+        const action = await handleFailure(err, debug, stdinInput);
+        if (action === "retry") {
+          continue;
+        }
+
+        if (err instanceof QError) {
+          process.exit(err.exitCode);
+        }
+
+        process.exit(1);
+      }
+    }
+  } catch (err) {
+    configureLogging({ debug });
+    updateLogContext({ configPath: getConfigPath() });
+    await handleFailure(err, debug, null);
+
+    if (err instanceof QError) {
+      process.exit(err.exitCode);
     }
 
-    // Security: Limit context length
-    if (context && context.length > MAX_CONTEXT_LENGTH) {
-      throw new UsageError(
-        `Context too long (${context.length} characters). Maximum is ${MAX_CONTEXT_LENGTH}.`,
-      );
-    }
+    process.exit(1);
+  }
+}
 
-    logDebug("Loading config...", debug);
-    const config = await loadConfig();
+async function runQueryAttempt(
+  args: ParsedArgs,
+  stdinInput: StdinInput,
+  debug: boolean,
+): Promise<void> {
+  // Resolve input mode and extract query/context
+  const { mode, query, context } = resolveInput(stdinInput, args.query);
+  updateLogContext({
+    mode,
+    queryLength: query.length,
+    contextLength: context?.length ?? 0,
+  });
+  logDebug(`Mode: ${mode}`, debug);
 
-    logDebug(
-      `Resolving provider: ${args.options.provider ?? config.default.provider}`,
-      debug,
+  // Security: Limit query length to prevent abuse and excessive API costs
+  if (query.length > MAX_QUERY_LENGTH) {
+    throw new UsageError(
+      `Query too long (${query.length} characters). Maximum is ${MAX_QUERY_LENGTH}.`,
     );
-    const { model, providerName, modelId } = resolveProvider(
-      config,
-      args.options.provider,
-      args.options.model,
-      debug,
+  }
+
+  // Security: Limit context length
+  if (context && context.length > MAX_CONTEXT_LENGTH) {
+    throw new UsageError(
+      `Context too long (${context.length} characters). Maximum is ${MAX_CONTEXT_LENGTH}.`,
     );
+  }
 
-    const envInfo = getEnvironmentInfo();
-    logDebug(`Query: ${query}`, debug);
-    logDebug(`Provider: ${providerName}, Model: ${modelId}`, debug);
-    logDebug(formatEnvForDebug(envInfo), debug);
+  logDebug("Loading config...", debug);
+  const config = await loadConfig();
 
+  logDebug(
+    `Resolving provider: ${args.options.provider ?? config.default.provider}`,
+    debug,
+  );
+  const { model, providerName, modelId } = resolveProvider(
+    config,
+    args.options.provider,
+    args.options.model,
+    debug,
+  );
+  updateLogContext({ provider: providerName, model: modelId });
+
+  const envInfo = getEnvironmentInfo();
+  logDebug(`Query: ${query}`, debug);
+  logDebug(`Provider: ${providerName}, Model: ${modelId}`, debug);
+  logDebug(formatEnvForDebug(envInfo), debug);
+
+  const loadingIndicator = startLoadingIndicator({
+    enabled: process.stderr.isTTY === true,
+  });
+
+  try {
     // Run the query (streams directly to stdout)
     const result = await runQuery({
       model,
       query,
       context,
       systemPrompt: buildSystemPrompt(envInfo),
+      onFirstChunk: () => loadingIndicator.stop(),
     });
 
     // Copy to clipboard if requested
@@ -113,24 +193,55 @@ async function main(): Promise<void> {
       await clipboard.write(safeClipboardText);
       logDebug("Copied to clipboard", debug);
     }
-
-    process.exit(0);
-  } catch (err) {
-    if (err instanceof QError) {
-      logError(err.message);
-      process.exit(err.exitCode);
-    }
-
-    // Unexpected error
-    const message = err instanceof Error ? err.message : String(err);
-    logError(`Unexpected error: ${message}`);
-
-    if (debug && err instanceof Error && err.stack) {
-      logError(err.stack);
-    }
-
-    process.exit(1);
+  } finally {
+    loadingIndicator.stop();
   }
+}
+
+async function handleFailure(
+  err: unknown,
+  debug: boolean,
+  stdinInput: StdinInput | null,
+): Promise<"exit" | "retry"> {
+  const displayMessage = getUserErrorMessage(err);
+  logError(`Error: ${displayMessage}`);
+
+  if (debug) {
+    printStderr(formatErrorDiagnostics(err));
+  }
+
+  let logPath: string | null = null;
+
+  if (shouldWriteFailureLog(err)) {
+    try {
+      logPath = await writeFailureLog(err, displayMessage);
+      printStderr(`Full log: ${logPath}`);
+    } catch (logWriteErr) {
+      printStderr("Could not write failure log.");
+
+      if (debug) {
+        printStderr(formatErrorDiagnostics(logWriteErr));
+      }
+    }
+  }
+
+  if (canRetryInteractively(err, stdinInput)) {
+    return promptForFailureRecovery(logPath);
+  }
+
+  return "exit";
+}
+
+function canRetryInteractively(
+  err: unknown,
+  stdinInput: StdinInput | null,
+): boolean {
+  return (
+    stdinInput !== null &&
+    stdinInput.hasInput === false &&
+    shouldWriteFailureLog(err) &&
+    canPromptForFailureRecovery()
+  );
 }
 
 main();

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,6 +7,7 @@ import {
   ConfigParseError,
   ConfigValidationError,
 } from "../errors.ts";
+import { logWarning } from "../logging.ts";
 
 export const ProviderType = z.enum([
   "openai",
@@ -207,11 +208,8 @@ export class Config {
         parsed.hostname.endsWith(".local");
 
       if (parsed.protocol === "http:" && !isLocalhost) {
-        console.error(
-          `Warning: Provider '${providerName}' uses insecure HTTP URL: ${url}`,
-        );
-        console.error(
-          "         Consider using HTTPS for non-localhost connections.",
+        logWarning(
+          `Provider '${providerName}' uses insecure HTTP URL: ${url}\nConsider using HTTPS for non-localhost connections.`,
         );
       }
     } catch {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,8 +2,9 @@ export class QError extends Error {
   constructor(
     message: string,
     public readonly exitCode: number,
+    options?: ErrorOptions,
   ) {
-    super(message);
+    super(message, options);
     this.name = "QError";
   }
 }
@@ -59,8 +60,8 @@ export class MissingApiKeyError extends QError {
 }
 
 export class ProviderError extends QError {
-  constructor(message: string) {
-    super(message, 1);
+  constructor(message: string, cause?: unknown) {
+    super(message, 1, cause === undefined ? undefined : { cause });
     this.name = "ProviderError";
   }
 }
@@ -72,12 +73,207 @@ export class UsageError extends QError {
   }
 }
 
-export function logError(message: string): void {
-  console.error(message);
+export function getUserErrorMessage(error: unknown): string {
+  if (error instanceof ConfigNotFoundError) {
+    return "Config file not found. Run 'q config init'.";
+  }
+
+  if (error instanceof ConfigParseError) {
+    return "Could not parse config file.";
+  }
+
+  if (error instanceof ConfigValidationError) {
+    return "Configuration is invalid. Check 'q config path'.";
+  }
+
+  if (error instanceof ProviderNotFoundError) {
+    return `Provider '${error.providerName}' is not configured.`;
+  }
+
+  if (error instanceof MissingApiKeyError) {
+    return `Missing API key. Set ${error.envVar}.`;
+  }
+
+  if (error instanceof ProviderError) {
+    return getProviderUserMessage(error);
+  }
+
+  if (error instanceof QError) {
+    return getFirstLine(error.message);
+  }
+
+  return "Unexpected error.";
 }
 
-export function logDebug(message: string, debug: boolean): void {
-  if (debug) {
-    console.error(`[debug] ${message}`);
+export function shouldWriteFailureLog(error: unknown): boolean {
+  return !(error instanceof UsageError);
+}
+
+function getFirstLine(message: string): string {
+  const [firstLine = message] = message.split("\n", 1);
+  return firstLine;
+}
+
+function getProviderUserMessage(error: ProviderError): string {
+  const detail =
+    extractProviderFailureDetail(error.cause) ??
+    extractProviderFailureDetail(error.message);
+
+  if (!detail) {
+    return "AI request failed.";
   }
+
+  return `AI request failed: ${detail}`;
+}
+
+function extractProviderFailureDetail(
+  value: unknown,
+  seen = new Set<unknown>(),
+): string | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    return normaliseProviderMessage(value);
+  }
+
+  if (typeof value !== "object") {
+    return normaliseProviderMessage(String(value));
+  }
+
+  if (seen.has(value)) {
+    return null;
+  }
+
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (let index = value.length - 1; index >= 0; index -= 1) {
+      const detail = extractProviderFailureDetail(value[index], seen);
+      if (detail) {
+        return detail;
+      }
+    }
+
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const fromCode = normaliseProviderCode(record.code);
+  if (fromCode) {
+    return fromCode;
+  }
+
+  const fromStatus = normaliseProviderStatus(record.statusCode);
+  if (fromStatus) {
+    return fromStatus;
+  }
+
+  const fromCause = extractProviderFailureDetail(record.cause, seen);
+  if (fromCause) {
+    return fromCause;
+  }
+
+  const fromErrors = extractProviderFailureDetail(record.errors, seen);
+  if (fromErrors) {
+    return fromErrors;
+  }
+
+  if (typeof record.message === "string") {
+    return normaliseProviderMessage(record.message);
+  }
+
+  return null;
+}
+
+function normaliseProviderCode(code: unknown): string | null {
+  if (typeof code !== "string") {
+    return null;
+  }
+
+  if (/^(?:ECONNREFUSED|ConnectionRefused)$/i.test(code)) {
+    return "could not connect to provider (connection refused).";
+  }
+
+  if (/^(?:ETIMEDOUT|TimeoutError|ConnectionTimeout)$/i.test(code)) {
+    return "request timed out.";
+  }
+
+  if (/^(?:ENOTFOUND|EAI_AGAIN)$/i.test(code)) {
+    return "could not resolve the provider host.";
+  }
+
+  return null;
+}
+
+function normaliseProviderStatus(statusCode: unknown): string | null {
+  if (typeof statusCode !== "number") {
+    return null;
+  }
+
+  switch (statusCode) {
+    case 401:
+      return "authentication failed.";
+    case 403:
+      return "permission denied.";
+    case 404:
+      return "requested resource was not found.";
+    case 429:
+      return "rate limit exceeded.";
+    default:
+      return null;
+  }
+}
+
+function normaliseProviderMessage(message: string): string | null {
+  const cleaned = cleanProviderMessage(message);
+
+  if (!cleaned) {
+    return null;
+  }
+
+  if (/connection refused/i.test(cleaned)) {
+    return "could not connect to provider (connection refused).";
+  }
+
+  if (/cannot connect to api|unable to connect/i.test(cleaned)) {
+    return "could not connect to provider.";
+  }
+
+  if (/timed out|timeout/i.test(cleaned)) {
+    return "request timed out.";
+  }
+
+  if (/rate limit/i.test(cleaned)) {
+    return "rate limit exceeded.";
+  }
+
+  if (/unauthori[sz]ed|authentication/i.test(cleaned)) {
+    return "authentication failed.";
+  }
+
+  if (/forbidden|permission denied/i.test(cleaned)) {
+    return "permission denied.";
+  }
+
+  return ensureTrailingPunctuation(cleaned);
+}
+
+function cleanProviderMessage(message: string): string {
+  const [firstLine = ""] = message
+    .replace(/^AI request failed:\s*/i, "")
+    .replace(/^Failed after \d+ attempts?\. Last error:\s*/i, "")
+    .replace(/^Error:\s*/i, "")
+    .split("\n", 1);
+
+  return ensureTrailingPunctuation(firstLine.trim());
+}
+
+function ensureTrailingPunctuation(message: string): string {
+  if (message === "") {
+    return message;
+  }
+
+  return /[.!?]$/.test(message) ? message : `${message}.`;
 }

--- a/src/failure-prompt.ts
+++ b/src/failure-prompt.ts
@@ -1,0 +1,107 @@
+import { readFile } from "node:fs/promises";
+import { printStderr, writeStderrRaw } from "./logging.ts";
+
+export type FailurePromptAction = "exit" | "retry" | "view_log";
+
+export function canPromptForFailureRecovery(): boolean {
+  return (
+    process.stdin.isTTY === true &&
+    process.stdout.isTTY === true &&
+    process.stderr.isTTY === true &&
+    typeof process.stdin.setRawMode === "function"
+  );
+}
+
+export function getFailurePromptMessage(hasLogFile: boolean): string {
+  if (hasLogFile) {
+    return "Press r to retry, Enter to view the full log, or q to exit.";
+  }
+
+  return "Press r to retry or q to exit.";
+}
+
+export function getFailurePromptAction(
+  input: string,
+  hasLogFile: boolean,
+): FailurePromptAction | null {
+  if (input === "r" || input === "R") {
+    return "retry";
+  }
+
+  if (
+    input === "q" ||
+    input === "Q" ||
+    input === "\u0003" ||
+    input === "\u001b"
+  ) {
+    return "exit";
+  }
+
+  if (hasLogFile && (input === "\r" || input === "\n")) {
+    return "view_log";
+  }
+
+  return null;
+}
+
+export async function promptForFailureRecovery(
+  logPath: string | null,
+): Promise<Exclude<FailurePromptAction, "view_log">> {
+  const hasLogFile = logPath !== null;
+
+  while (true) {
+    printStderr(getFailurePromptMessage(hasLogFile));
+
+    const action = await readFailurePromptAction(hasLogFile);
+    if (action === "view_log") {
+      await showFailureLog(logPath);
+      continue;
+    }
+
+    return action;
+  }
+}
+
+async function readFailurePromptAction(
+  hasLogFile: boolean,
+): Promise<FailurePromptAction> {
+  const stdin = process.stdin;
+  const wasRaw = Boolean(
+    (stdin as NodeJS.ReadStream & { isRaw?: boolean }).isRaw,
+  );
+
+  stdin.setRawMode?.(true);
+  stdin.resume();
+
+  try {
+    return await new Promise<FailurePromptAction>((resolve) => {
+      const onData = (chunk: Buffer | string) => {
+        const input = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+        const action = getFailurePromptAction(input, hasLogFile);
+
+        if (!action) {
+          return;
+        }
+
+        stdin.off("data", onData);
+        resolve(action);
+      };
+
+      stdin.on("data", onData);
+    });
+  } finally {
+    stdin.setRawMode?.(wasRaw);
+    stdin.pause();
+  }
+}
+
+async function showFailureLog(logPath: string | null): Promise<void> {
+  if (!logPath) {
+    return;
+  }
+
+  const content = await readFile(logPath, "utf8");
+  printStderr("");
+  printStderr("Failure log:");
+  writeStderrRaw(content);
+}

--- a/src/loading-indicator.ts
+++ b/src/loading-indicator.ts
@@ -1,0 +1,62 @@
+export interface LoadingIndicatorStream {
+  isTTY?: boolean;
+  write(chunk: string): boolean;
+}
+
+export interface LoadingIndicator {
+  stop(): void;
+}
+
+export interface LoadingIndicatorOptions {
+  enabled?: boolean;
+  intervalMs?: number;
+  stream?: LoadingIndicatorStream;
+  text?: string;
+}
+
+const DEFAULT_FRAMES = ["-", "\\", "|", "/"];
+const DEFAULT_INTERVAL_MS = 80;
+const DEFAULT_TEXT = "Thinking...";
+
+export function startLoadingIndicator(
+  options: LoadingIndicatorOptions = {},
+): LoadingIndicator {
+  const {
+    enabled = true,
+    intervalMs = DEFAULT_INTERVAL_MS,
+    stream = process.stderr,
+    text = DEFAULT_TEXT,
+  } = options;
+
+  if (!enabled || stream.isTTY !== true) {
+    return { stop() {} };
+  }
+
+  let frameIndex = 0;
+  let active = true;
+  let lastFrameLength = 0;
+
+  const render = () => {
+    const frame = `${DEFAULT_FRAMES[frameIndex]} ${text}`;
+    lastFrameLength = frame.length;
+    stream.write(`\r${frame}`);
+    frameIndex = (frameIndex + 1) % DEFAULT_FRAMES.length;
+  };
+
+  render();
+
+  const timer = setInterval(render, intervalMs);
+  timer.unref?.();
+
+  return {
+    stop() {
+      if (!active) {
+        return;
+      }
+
+      active = false;
+      clearInterval(timer);
+      stream.write(`\r${" ".repeat(lastFrameLength)}\r`);
+    },
+  };
+}

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,264 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import envPaths from "env-paths";
+import pc from "picocolors";
+import pkg from "../package.json";
+
+type LogLevel = "debug" | "warn" | "error";
+type LogContextValue = boolean | number | string;
+
+interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+}
+
+const sessionEntries: LogEntry[] = [];
+const sessionContext = new Map<string, LogContextValue>();
+
+export function configureLogging(options: { debug: boolean }): void {
+  sessionEntries.length = 0;
+  sessionContext.clear();
+  updateLogContext({ debug: options.debug });
+}
+
+export function updateLogContext(
+  context: Record<string, LogContextValue | null | undefined>,
+): void {
+  for (const [key, value] of Object.entries(context)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    sessionContext.set(key, value);
+  }
+}
+
+export function logDebug(message: string, debug: boolean): void {
+  if (!debug) {
+    return;
+  }
+
+  recordLogEntry("debug", message);
+  printStderr(`[debug] ${message}`);
+}
+
+export function logWarning(message: string): void {
+  recordLogEntry("warn", message);
+  printStderr(`Warning: ${message}`);
+}
+
+export function logError(message: string): void {
+  recordLogEntry("error", message);
+  printStderr(message);
+}
+
+export function printStderr(message: string): void {
+  console.error(formatStderrMessage(message));
+}
+
+export function writeStderrRaw(message: string): void {
+  process.stderr.write(message.endsWith("\n") ? message : `${message}\n`);
+}
+
+export function formatStderrMessage(
+  message: string,
+  colourEnabled?: boolean,
+): string {
+  const colours = pc.createColors(colourEnabled);
+
+  if (message.startsWith("Error:")) {
+    return formatPrefixedMessage(message, "Error:", (value) =>
+      colours.bold(colours.red(value)),
+    );
+  }
+
+  if (message.startsWith("Warning:")) {
+    return formatPrefixedMessage(message, "Warning:", colours.yellow);
+  }
+
+  if (message.startsWith("[debug]")) {
+    return formatPrefixedMessage(message, "[debug]", colours.dim);
+  }
+
+  if (message.startsWith("Full log:")) {
+    const path = message.slice("Full log:".length).trimStart();
+    return `${colours.dim("Full log:")} ${colours.cyan(path)}`;
+  }
+
+  return message;
+}
+
+export function formatErrorDiagnostics(error: unknown): string {
+  return formatUnknownValue(error);
+}
+
+export function getFailureLogDir(): string {
+  return join(envPaths("q", { suffix: "" }).log, "errors");
+}
+
+export async function writeFailureLog(
+  error: unknown,
+  displayMessage: string,
+): Promise<string> {
+  const logDir = getFailureLogDir();
+  await mkdir(logDir, { recursive: true });
+
+  const timestamp = new Date();
+  const fileName = `error-${timestamp.toISOString().replaceAll(":", "-")}.log`;
+  const logPath = join(logDir, fileName);
+  const report = buildFailureReport(
+    timestamp.toISOString(),
+    displayMessage,
+    error,
+  );
+
+  await writeFile(logPath, report, "utf8");
+  return logPath;
+}
+
+function recordLogEntry(level: LogLevel, message: string): void {
+  sessionEntries.push({
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+  });
+}
+
+function buildFailureReport(
+  timestamp: string,
+  displayMessage: string,
+  error: unknown,
+): string {
+  const sections = [
+    "q failure log",
+    `Timestamp: ${timestamp}`,
+    `Version: ${pkg.version}`,
+    `Runtime: ${getRuntimeLabel()}`,
+    `Platform: ${process.platform}`,
+    `Architecture: ${process.arch}`,
+    `Working directory: ${process.cwd()}`,
+    "",
+    "Display message:",
+    displayMessage,
+    "",
+    "Session context:",
+    formatSessionContext(),
+    "",
+    "Error details:",
+    formatErrorDiagnostics(error),
+    "",
+    "Session log:",
+    formatSessionEntries(),
+    "",
+  ];
+
+  return sections.join("\n");
+}
+
+function getRuntimeLabel(): string {
+  if (typeof Bun !== "undefined") {
+    return `Bun ${Bun.version}`;
+  }
+
+  return `Node ${process.version}`;
+}
+
+function formatSessionContext(): string {
+  if (sessionContext.size === 0) {
+    return "(none)";
+  }
+
+  return [...sessionContext.entries()]
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([key, value]) => `${key}: ${String(value)}`)
+    .join("\n");
+}
+
+function formatSessionEntries(): string {
+  if (sessionEntries.length === 0) {
+    return "(none)";
+  }
+
+  return sessionEntries
+    .map((entry) => `[${entry.timestamp}] [${entry.level}] ${entry.message}`)
+    .join("\n");
+}
+
+function formatUnknownValue(value: unknown, depth = 0): string {
+  const prefix = "  ".repeat(depth);
+
+  if (value instanceof Error) {
+    const lines = [
+      `${prefix}name: ${value.name}`,
+      `${prefix}message: ${value.message}`,
+    ];
+
+    const properties = Object.entries(value).filter(
+      ([key]) =>
+        key !== "name" &&
+        key !== "message" &&
+        key !== "stack" &&
+        key !== "cause",
+    );
+
+    if (properties.length > 0) {
+      lines.push(`${prefix}properties:`);
+      for (const [key, propertyValue] of properties) {
+        lines.push(`${prefix}  ${key}: ${formatValue(propertyValue)}`);
+      }
+    }
+
+    if (value.cause !== undefined) {
+      lines.push(`${prefix}cause:`);
+      lines.push(formatUnknownValue(value.cause, depth + 1));
+    }
+
+    if (value.stack) {
+      lines.push(`${prefix}stack:`);
+      lines.push(indentBlock(value.stack, depth + 1));
+    }
+
+    return lines.join("\n");
+  }
+
+  return `${prefix}${formatValue(value)}`;
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null ||
+    value === undefined
+  ) {
+    return String(value);
+  }
+
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function indentBlock(value: string, depth: number): string {
+  const prefix = "  ".repeat(depth);
+  return value
+    .split("\n")
+    .map((line) => `${prefix}${line}`)
+    .join("\n");
+}
+
+function formatPrefixedMessage(
+  message: string,
+  prefix: string,
+  style: (value: string) => string,
+): string {
+  const remainder = message.slice(prefix.length);
+  return `${style(prefix)}${remainder}`;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,10 +1,7 @@
 import type { LanguageModel } from "ai";
 import type { ConfigData, ProviderConfig } from "../config/index.ts";
-import {
-  logDebug,
-  MissingApiKeyError,
-  ProviderNotFoundError,
-} from "../errors.ts";
+import { MissingApiKeyError, ProviderNotFoundError } from "../errors.ts";
+import { logDebug } from "../logging.ts";
 import { createAnthropicProvider } from "./anthropic.ts";
 import { createAzureProvider } from "./azure.ts";
 import { createBedrockProvider } from "./bedrock.ts";

--- a/src/providers/portkey.ts
+++ b/src/providers/portkey.ts
@@ -1,6 +1,7 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import type { ProviderConfig } from "../config/index.ts";
-import { ConfigValidationError, logDebug } from "../errors.ts";
+import { ConfigValidationError } from "../errors.ts";
+import { logDebug } from "../logging.ts";
 import { resolveApiKey } from "./index.ts";
 
 /**

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,6 +9,7 @@ export interface RunOptions {
   query: string;
   systemPrompt: string;
   context?: string | null;
+  onFirstChunk?: () => void;
 }
 
 export interface RunResult {
@@ -16,26 +17,45 @@ export interface RunResult {
 }
 
 export async function runQuery(options: RunOptions): Promise<RunResult> {
-  const { model, query, systemPrompt, context } = options;
+  const { model, query, systemPrompt, context, onFirstChunk } = options;
   const userPrompt = buildUserPrompt(query, context);
 
   try {
+    let streamError: unknown;
+
     const result = streamText({
       model,
       system: systemPrompt,
       prompt: userPrompt,
+      onError: ({ error }) => {
+        streamError ??= error;
+      },
     });
 
     let fullText = "";
+    let sawTextChunk = false;
     const stripper = createAnsiStripper();
 
     for await (const textPart of result.textStream) {
+      if (!sawTextChunk) {
+        sawTextChunk = true;
+        onFirstChunk?.();
+      }
+
       // Security: Strip ANSI codes to prevent terminal manipulation
       // We keep original text in fullText for the return value (e.g. for clipboard)
       // but sanitize stdout to protect the user's terminal
       const safeText = stripper(textPart);
       process.stdout.write(safeText);
       fullText += textPart;
+    }
+
+    if (streamError !== undefined) {
+      if (fullText !== "" && !fullText.endsWith("\n")) {
+        process.stdout.write("\n");
+      }
+
+      throw streamError;
     }
 
     // Check against safeText buffer equivalent would be ideal but complex.
@@ -47,6 +67,6 @@ export async function runQuery(options: RunOptions): Promise<RunResult> {
     return { text: fullText };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    throw new ProviderError(`AI request failed: ${message}`);
+    throw new ProviderError(`AI request failed: ${message}`, err);
   }
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,10 +1,21 @@
 import { execSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const projectRoot = resolve(import.meta.dirname, "..");
 
-function runCli(args: string): {
+function runCli(
+  args: string,
+  envOverrides: Record<string, string | undefined> = {},
+): {
   stdout: string;
   stderr: string;
   exitCode: number;
@@ -19,6 +30,8 @@ function runCli(args: string): {
         Q_PROVIDER: undefined,
         Q_MODEL: undefined,
         Q_COPY: undefined,
+        NO_COLOR: "1",
+        ...envOverrides,
       },
     });
     return { stdout: stdout.trim(), stderr: "", exitCode: 0 };
@@ -34,6 +47,41 @@ function runCli(args: string): {
       exitCode: e.status ?? 1,
     };
   }
+}
+
+function createIsolatedEnv(): {
+  rootDir: string;
+  env: {
+    HOME: string;
+    XDG_CONFIG_HOME: string;
+    XDG_STATE_HOME: string;
+    NO_COLOR: string;
+  };
+} {
+  const rootDir = mkdtempSync(resolve(tmpdir(), "q-cli-"));
+  const homeDir = resolve(rootDir, "home");
+  const configDir = resolve(rootDir, "config");
+  const stateDir = resolve(rootDir, "state");
+
+  mkdirSync(homeDir, { recursive: true });
+  mkdirSync(configDir, { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
+
+  return {
+    rootDir,
+    env: {
+      HOME: homeDir,
+      XDG_CONFIG_HOME: configDir,
+      XDG_STATE_HOME: stateDir,
+      NO_COLOR: "1",
+    },
+  };
+}
+
+function writeConfig(env: { XDG_CONFIG_HOME: string }, contents: string): void {
+  const configPath = resolve(env.XDG_CONFIG_HOME, "q", "config.toml");
+  mkdirSync(resolve(env.XDG_CONFIG_HOME, "q"), { recursive: true });
+  writeFileSync(configPath, contents, "utf8");
 }
 
 describe("CLI integration", () => {
@@ -69,7 +117,90 @@ describe("CLI integration", () => {
   });
 
   it("rejects unknown config subcommands", () => {
-    const { exitCode } = runCli("config unknown");
+    const { stderr, exitCode } = runCli("config unknown");
     expect(exitCode).not.toBe(0);
+    expect(stderr).not.toContain("Full log:");
   });
+
+  it("prints concise config errors and writes a failure log", () => {
+    const { rootDir, env } = createIsolatedEnv();
+
+    try {
+      const { stderr, exitCode } = runCli("hello", env);
+
+      expect(exitCode).toBe(2);
+      expect(stderr).toContain(
+        "Error: Config file not found. Run 'q config init'.",
+      );
+      expect(stderr).toContain("Full log: ");
+      expect(stderr).not.toContain("Error: Config file not found:");
+
+      const match = stderr.match(/^Full log: (.+)$/m);
+      expect(match?.[1]).toBeTruthy();
+
+      const logPath = match?.[1];
+      expect(logPath).toContain(resolve(env.XDG_STATE_HOME, "q", "errors"));
+
+      const logContent = readFileSync(logPath as string, "utf8");
+      expect(logContent).toContain(
+        "Display message:\nConfig file not found. Run 'q config init'.",
+      );
+      expect(logContent).toContain("Config file not found:");
+      expect(logContent).toContain("Session context:");
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps debug diagnostics on stderr and still writes a failure log", () => {
+    const { rootDir, env } = createIsolatedEnv();
+
+    try {
+      const { stderr, exitCode } = runCli("--debug hello", env);
+
+      expect(exitCode).toBe(2);
+      expect(stderr).toContain("[debug] Mode:");
+      expect(stderr).toContain("[debug] Loading config...");
+      expect(stderr).toContain(
+        "Error: Config file not found. Run 'q config init'.",
+      );
+      expect(stderr).toContain("name: ConfigNotFoundError");
+      expect(stderr).toContain("Full log: ");
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("shows concise provider failures instead of raw SDK errors", () => {
+    const { rootDir, env } = createIsolatedEnv();
+
+    try {
+      writeConfig(
+        env,
+        [
+          "[default]",
+          'provider = "local"',
+          'model = "test-model"',
+          "",
+          "[providers.local]",
+          'type = "ollama"',
+          'base_url = "http://127.0.0.1:1/api"',
+          "",
+        ].join("\n"),
+      );
+
+      const { stderr, exitCode } = runCli("hello", env);
+
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain(
+        "Error: AI request failed: could not connect to provider (connection refused).",
+      );
+      expect(stderr).toContain("Full log: ");
+      expect(stderr).not.toContain("AI_RetryError");
+      expect(stderr).not.toContain("AI_APICallError");
+      expect(stderr).not.toContain("ConnectionRefused");
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  }, 15_000);
 });

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  ConfigNotFoundError,
+  ConfigParseError,
+  ConfigValidationError,
+  getUserErrorMessage,
+  MissingApiKeyError,
+  ProviderError,
+  ProviderNotFoundError,
+  shouldWriteFailureLog,
+  UsageError,
+} from "../src/errors.ts";
+
+describe("getUserErrorMessage", () => {
+  it("formats missing config errors concisely", () => {
+    expect(
+      getUserErrorMessage(new ConfigNotFoundError("/tmp/config.toml")),
+    ).toBe("Config file not found. Run 'q config init'.");
+  });
+
+  it("formats config parse errors concisely", () => {
+    expect(
+      getUserErrorMessage(new ConfigParseError("/tmp/config.toml", "bad toml")),
+    ).toBe("Could not parse config file.");
+  });
+
+  it("formats config validation errors concisely", () => {
+    expect(getUserErrorMessage(new ConfigValidationError("bad config"))).toBe(
+      "Configuration is invalid. Check 'q config path'.",
+    );
+  });
+
+  it("formats missing API key errors concisely", () => {
+    expect(
+      getUserErrorMessage(
+        new MissingApiKeyError("ANTHROPIC_API_KEY", "anthropic"),
+      ),
+    ).toBe("Missing API key. Set ANTHROPIC_API_KEY.");
+  });
+
+  it("formats provider lookup errors concisely", () => {
+    expect(getUserErrorMessage(new ProviderNotFoundError("openai"))).toBe(
+      "Provider 'openai' is not configured.",
+    );
+  });
+
+  it("formats provider failures concisely", () => {
+    expect(
+      getUserErrorMessage(new ProviderError("AI request failed: timeout")),
+    ).toBe("AI request failed: request timed out.");
+  });
+
+  it("prefers nested connection codes for provider failures", () => {
+    expect(
+      getUserErrorMessage(
+        new ProviderError("AI request failed: Failed after 3 attempts.", {
+          errors: [
+            {
+              message: "Cannot connect to API: Unable to connect.",
+              cause: { code: "ConnectionRefused" },
+            },
+          ],
+        }),
+      ),
+    ).toBe(
+      "AI request failed: could not connect to provider (connection refused).",
+    );
+  });
+
+  it("maps provider status codes to direct messages", () => {
+    expect(
+      getUserErrorMessage(
+        new ProviderError("AI request failed: 429", { statusCode: 429 }),
+      ),
+    ).toBe("AI request failed: rate limit exceeded.");
+  });
+
+  it("uses first line for usage errors", () => {
+    expect(
+      getUserErrorMessage(new UsageError("Unknown option\nRun q --help")),
+    ).toBe("Unknown option");
+  });
+
+  it("falls back to a generic message for unexpected errors", () => {
+    expect(getUserErrorMessage(new Error("boom"))).toBe("Unexpected error.");
+    expect(getUserErrorMessage("boom")).toBe("Unexpected error.");
+  });
+});
+
+describe("shouldWriteFailureLog", () => {
+  it("skips usage errors", () => {
+    expect(shouldWriteFailureLog(new UsageError("Unknown option"))).toBe(false);
+  });
+
+  it("writes logs for config errors", () => {
+    expect(
+      shouldWriteFailureLog(new ConfigNotFoundError("/tmp/config.toml")),
+    ).toBe(true);
+  });
+
+  it("writes logs for unexpected errors", () => {
+    expect(shouldWriteFailureLog(new Error("boom"))).toBe(true);
+  });
+});

--- a/tests/failure-prompt.test.ts
+++ b/tests/failure-prompt.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  getFailurePromptAction,
+  getFailurePromptMessage,
+} from "../src/failure-prompt.ts";
+
+describe("failure prompt", () => {
+  it("describes all interactive options when a log is available", () => {
+    expect(getFailurePromptMessage(true)).toBe(
+      "Press r to retry, Enter to view the full log, or q to exit.",
+    );
+  });
+
+  it("describes retry and exit when no log is available", () => {
+    expect(getFailurePromptMessage(false)).toBe(
+      "Press r to retry or q to exit.",
+    );
+  });
+
+  it("maps supported keys to actions", () => {
+    expect(getFailurePromptAction("r", true)).toBe("retry");
+    expect(getFailurePromptAction("R", true)).toBe("retry");
+    expect(getFailurePromptAction("\r", true)).toBe("view_log");
+    expect(getFailurePromptAction("q", true)).toBe("exit");
+    expect(getFailurePromptAction("\u001b", true)).toBe("exit");
+  });
+
+  it("ignores unsupported keys", () => {
+    expect(getFailurePromptAction("\r", false)).toBeNull();
+    expect(getFailurePromptAction("x", true)).toBeNull();
+    expect(getFailurePromptAction("\u001b[A", true)).toBeNull();
+  });
+});

--- a/tests/loading-indicator.test.ts
+++ b/tests/loading-indicator.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startLoadingIndicator } from "../src/loading-indicator.ts";
+
+describe("startLoadingIndicator", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders frames and clears them on stop", () => {
+    vi.useFakeTimers();
+
+    const writes: string[] = [];
+    const indicator = startLoadingIndicator({
+      intervalMs: 50,
+      stream: {
+        isTTY: true,
+        write(chunk: string) {
+          writes.push(chunk);
+          return true;
+        },
+      },
+      text: "Working...",
+    });
+
+    expect(writes).toEqual(["\r- Working..."]);
+
+    vi.advanceTimersByTime(100);
+
+    expect(writes).toEqual([
+      "\r- Working...",
+      "\r\\ Working...",
+      "\r| Working...",
+    ]);
+
+    indicator.stop();
+
+    expect(writes[writes.length - 1]).toBe("\r            \r");
+  });
+
+  it("does nothing when the stream is not a TTY", () => {
+    const write = vi.fn();
+
+    const indicator = startLoadingIndicator({
+      stream: {
+        isTTY: false,
+        write,
+      },
+    });
+
+    indicator.stop();
+
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { formatStderrMessage } from "../src/logging.ts";
+
+describe("formatStderrMessage", () => {
+  it("keeps plain text when colour is disabled", () => {
+    expect(formatStderrMessage("Error: Boom", false)).toBe("Error: Boom");
+    expect(formatStderrMessage("Warning: Careful", false)).toBe(
+      "Warning: Careful",
+    );
+    expect(formatStderrMessage("[debug] hello", false)).toBe("[debug] hello");
+    expect(formatStderrMessage("Full log: /tmp/q.log", false)).toBe(
+      "Full log: /tmp/q.log",
+    );
+  });
+
+  it("adds light colour when enabled", () => {
+    const errorLine = formatStderrMessage("Error: Boom", true);
+    const warningLine = formatStderrMessage("Warning: Careful", true);
+    const debugLine = formatStderrMessage("[debug] hello", true);
+    const logLine = formatStderrMessage("Full log: /tmp/q.log", true);
+
+    expect(errorLine).toContain("\u001B[");
+    expect(errorLine).toContain("Error:");
+    expect(warningLine).toContain("\u001B[");
+    expect(warningLine).toContain("Warning:");
+    expect(debugLine).toContain("\u001B[");
+    expect(debugLine).toContain("[debug]");
+    expect(logLine).toContain("\u001B[");
+    expect(logLine).toContain("Full log:");
+    expect(logLine).toContain("/tmp/q.log");
+  });
+});

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -36,6 +36,34 @@ describe("runQuery", () => {
     writeSpy.mockRestore();
   });
 
+  it("calls onFirstChunk once before writing streamed output", async () => {
+    mockStreamText.mockReturnValue({
+      textStream: (async function* () {
+        yield "hello ";
+        yield "world\n";
+      })(),
+    });
+
+    const writeSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const onFirstChunk = vi.fn();
+
+    await runQuery({
+      // @ts-expect-error - mocking model
+      model: {},
+      query: "test",
+      systemPrompt: "test",
+      onFirstChunk,
+    });
+
+    expect(onFirstChunk).toHaveBeenCalledTimes(1);
+    expect(onFirstChunk.mock.invocationCallOrder[0]).toBeLessThan(
+      writeSpy.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    writeSpy.mockRestore();
+  });
+
   it("adds trailing newline if text does not end with one", async () => {
     mockStreamText.mockReturnValue({
       textStream: (async function* () {
@@ -171,6 +199,67 @@ describe("runQuery", () => {
     });
 
     expect(result.text).toBe("");
+    writeSpy.mockRestore();
+  });
+
+  it("throws when the SDK reports an error via onError", async () => {
+    mockStreamText.mockImplementation(
+      (opts: { onError?: (event: { error: unknown }) => void }) => {
+        opts.onError?.({ error: new Error("connection refused") });
+
+        return {
+          textStream: (async function* () {})(),
+        };
+      },
+    );
+
+    const writeSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runQuery({
+        // @ts-expect-error - mocking model
+        model: {},
+        query: "test",
+        systemPrompt: "test",
+      }),
+    ).rejects.toThrow("AI request failed: connection refused");
+
+    expect(writeSpy).not.toHaveBeenCalled();
+    writeSpy.mockRestore();
+  });
+
+  it("adds a newline before throwing after partial streamed output", async () => {
+    mockStreamText.mockImplementation(
+      (opts: { onError?: (event: { error: unknown }) => void }) => {
+        opts.onError?.({ error: new Error("stream interrupted") });
+
+        return {
+          textStream: (async function* () {
+            yield "partial";
+          })(),
+        };
+      },
+    );
+
+    const writeSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runQuery({
+        // @ts-expect-error - mocking model
+        model: {},
+        query: "test",
+        systemPrompt: "test",
+      }),
+    ).rejects.toThrow("AI request failed: stream interrupted");
+
+    expect(writeSpy.mock.calls.map((call) => call[0])).toEqual([
+      "partial",
+      "\n",
+    ]);
     writeSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- make CLI failures concise and actionable while still writing detailed failure logs for debugging
- add interactive TTY recovery with retry, full-log viewing, and a small loading spinner while waiting for the first response token
- add regression coverage for provider stream errors, stderr formatting, prompts, and spinner behaviour

## Testing
- bun run lint
- bun run typecheck
- bun run test
- bun run build