### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive data leak in error logging via JSON stringification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -29,3 +29,8 @@
 **Vulnerability:** In `src/providers/portkey.ts`, the logging code meant to mask sensitive headers (like `Authorization` or `x-portkey-api-key`) was flawed. If a sensitive value was 12 characters or less, it was completely exposed in plain text in the debug logs instead of being masked.
 **Learning:** Conditional masking logic often fails to account for shorter strings or edge cases in lengths. When using a ternary that checks for length, ensure the alternate case for a shorter length securely masks the string rather than falling through to the unmasked original value.
 **Prevention:** Fully mask short strings (e.g., using `"********"`) and verify boundary conditions for all sensitive data redaction functions.
+
+## 2026-03-08 - Secret Leakage in Debug Logs via JSON Stringification
+**Vulnerability:** When stringifying deeply nested objects for logging or error reporting (e.g. `JSON.stringify(error)`), sensitive fields such as HTTP headers (`Authorization`, `x-api-key`) nested inside error properties or configurations could be written to disk in plain text.
+**Learning:** Relying solely on key deletion filtering functions can cause issues with arrays or custom `toJSON` serialization methods. Global `.includes()` checks can incorrectly redact safe keys containing substrings like 'token' (e.g., `promptTokens`). Also, low-level modules like `logging.ts` shouldn't import higher-level application modules to avoid circular dependencies.
+**Prevention:** Use the native `replacer` function argument in `JSON.stringify` configured with exact, strict matches and suffix checks (e.g., `=== 'authorization'` or `.endsWith('_key')`) to target strictly sensitive tokens safely.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -225,6 +225,32 @@ function formatUnknownValue(value: unknown, depth = 0): string {
   return `${prefix}${formatValue(value)}`;
 }
 
+const SENSITIVE_KEYS = new Set([
+  "authorization",
+  "password",
+  "secret",
+  "token",
+  "api_key",
+  "apikey",
+  "access_token",
+  "refresh_token",
+]);
+
+function secureReplacer(key: string, value: unknown): unknown {
+  if (key && typeof key === "string") {
+    const lowerKey = key.toLowerCase();
+    if (
+      SENSITIVE_KEYS.has(lowerKey) ||
+      lowerKey.endsWith("_key") ||
+      lowerKey.endsWith("apikey") ||
+      lowerKey === "x-api-key"
+    ) {
+      return "[REDACTED]";
+    }
+  }
+  return value;
+}
+
 function formatValue(value: unknown): string {
   if (typeof value === "string") {
     return value;
@@ -240,7 +266,7 @@ function formatValue(value: unknown): string {
   }
 
   try {
-    return JSON.stringify(value, null, 2);
+    return JSON.stringify(value, secureReplacer, 2);
   } catch {
     return String(value);
   }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,7 @@ import type { LanguageModel } from "ai";
 import type { ConfigData, ProviderConfig } from "../config/index.ts";
 import { MissingApiKeyError, ProviderNotFoundError } from "../errors.ts";
 import { logDebug } from "../logging.ts";
+import { filterSensitiveFields } from "../sensitive.ts";
 import { createAnthropicProvider } from "./anthropic.ts";
 import { createAzureProvider } from "./azure.ts";
 import { createBedrockProvider } from "./bedrock.ts";
@@ -16,46 +17,6 @@ export interface ResolvedProvider {
   model: LanguageModel;
   providerName: string;
   modelId: string;
-}
-
-const SENSITIVE_FIELD_PATTERNS = [
-  "key",
-  "secret",
-  "token",
-  "password",
-  "auth",
-  "credential",
-];
-
-function isSensitiveKey(key: string): boolean {
-  const lowerKey = key.toLowerCase();
-  return SENSITIVE_FIELD_PATTERNS.some((pattern) => lowerKey.includes(pattern));
-}
-
-/**
- * Filter sensitive fields from a provider config for safe logging.
- * Removes any field containing: key, secret, token, password, auth, credential.
- * Also recursively filters nested objects like headers.
- * @internal Exported for testing only
- */
-export function filterSensitiveFields(
-  config: Record<string, unknown>,
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-
-  for (const [key, value] of Object.entries(config)) {
-    if (isSensitiveKey(key)) {
-      continue;
-    }
-
-    if (value && typeof value === "object" && !Array.isArray(value)) {
-      result[key] = filterSensitiveFields(value as Record<string, unknown>);
-    } else {
-      result[key] = value;
-    }
-  }
-
-  return result;
 }
 
 /**

--- a/src/sensitive.ts
+++ b/src/sensitive.ts
@@ -1,0 +1,43 @@
+const SENSITIVE_FIELD_PATTERNS = [
+  "key",
+  "secret",
+  "token",
+  "password",
+  "auth",
+  "credential",
+];
+
+function isSensitiveKey(key: string): boolean {
+  const lowerKey = key.toLowerCase();
+  return SENSITIVE_FIELD_PATTERNS.some((pattern) => lowerKey.includes(pattern));
+}
+
+/**
+ * Filter sensitive fields from a provider config for safe logging.
+ * Removes any field containing: key, secret, token, password, auth, credential.
+ * Also recursively filters nested objects like headers.
+ */
+export function filterSensitiveFields(
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(config)) {
+    if (isSensitiveKey(key)) {
+      continue;
+    }
+
+    if (
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      !(value instanceof Date)
+    ) {
+      result[key] = filterSensitiveFields(value as Record<string, unknown>);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatStderrMessage } from "../src/logging.ts";
+import { formatErrorDiagnostics, formatStderrMessage } from "../src/logging.ts";
 
 describe("formatStderrMessage", () => {
   it("keeps plain text when colour is disabled", () => {
@@ -28,5 +28,82 @@ describe("formatStderrMessage", () => {
     expect(logLine).toContain("\u001B[");
     expect(logLine).toContain("Full log:");
     expect(logLine).toContain("/tmp/q.log");
+  });
+});
+
+describe("formatErrorDiagnostics", () => {
+  it("redacts sensitive fields in error properties", () => {
+    const error = new Error("Test error") as Error & { config?: unknown };
+    error.config = {
+      headers: {
+        Authorization: "Bearer super-secret-token",
+        "X-API-Key": "my-api-key",
+      },
+      url: "https://api.example.com",
+    };
+
+    const output = formatErrorDiagnostics(error);
+
+    expect(output).toContain("name: Error");
+    expect(output).toContain("message: Test error");
+    expect(output).toContain("https://api.example.com");
+    expect(output).not.toContain("super-secret-token");
+    expect(output).not.toContain("my-api-key");
+  });
+
+  it("redacts sensitive fields in nested cause objects", () => {
+    const rootError = new Error("Root error");
+    const causeError = new Error("Cause error") as Error & {
+      requestDetails?: unknown;
+    };
+
+    causeError.requestDetails = {
+      password: "my-password",
+      token: "secret-token",
+    };
+    rootError.cause = causeError;
+
+    const output = formatErrorDiagnostics(rootError);
+
+    expect(output).toContain("name: Error");
+    expect(output).toContain("message: Root error");
+    expect(output).toContain("cause:");
+    expect(output).toContain("message: Cause error");
+    expect(output).not.toContain("my-password");
+    expect(output).not.toContain("secret-token");
+  });
+
+  it("redacts sensitive fields in arrays", () => {
+    const error = new Error("Test array error") as Error & {
+      identities?: unknown;
+    };
+    error.identities = [
+      { id: 1, token: "first-secret" },
+      { id: 2, API_KEY: "second-secret" },
+    ];
+
+    const output = formatErrorDiagnostics(error);
+    expect(output).toContain("name: Error");
+    expect(output).toContain("message: Test array error");
+    expect(output).toContain('"id": 1');
+    expect(output).not.toContain("first-secret");
+    expect(output).not.toContain("second-secret");
+    expect(output).toContain("[REDACTED]");
+  });
+
+  it("does not redact safe keys containing token/key substrings", () => {
+    const error = new Error("Test safe keys") as Error & { metrics?: unknown };
+    error.metrics = {
+      promptTokens: 100,
+      completionTokens: 200,
+      totalTokens: 300,
+      monkey: "banana",
+    };
+
+    const output = formatErrorDiagnostics(error);
+    expect(output).toContain('"promptTokens": 100');
+    expect(output).toContain('"completionTokens": 200');
+    expect(output).toContain('"totalTokens": 300');
+    expect(output).toContain('"monkey": "banana"');
   });
 });

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { parseCliArgs } from "../src/args.ts";
 import { interpolateValue } from "../src/config/index.ts";
 import { ConfigValidationError } from "../src/errors.ts";
-import { filterSensitiveFields } from "../src/providers/index.ts";
+import { filterSensitiveFields } from "../src/sensitive.ts";
 
 describe("security", () => {
   describe("query length validation", () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When stringifying deeply nested objects for logging or error reporting (`JSON.stringify(error)`), sensitive fields such as HTTP headers (`Authorization`, `x-api-key`) nested inside error properties (like `.config`) could be written to disk in plain text. Also previously, if a property contained an array of objects holding secrets, those secrets would bypass the redaction.
🎯 Impact: Attackers or users could gain unauthorized access to AI provider API keys or other sensitive credentials stored in failure logs.
🔧 Fix: Used the native `replacer` function argument in `JSON.stringify` within `logging.ts`, configured with exact, strict matches and suffix checks (e.g., `=== 'authorization'` or `.endsWith('_key')`) to target strictly sensitive tokens safely. This also correctly handles array contents without messing up the native `JSON.stringify` serialization formatting.
✅ Verification: Ran `bun run test` making sure that arrays are now redacted, and safe metric keys (like `promptTokens`) are no longer falsely redacted.

---
*PR created automatically by Jules for task [9753102305255084077](https://jules.google.com/task/9753102305255084077) started by @hongymagic*