### PR TITLE
🛡️ Sentinel: [security improvement] Consistent secret redaction

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -212,7 +212,7 @@ function formatUnknownValue(value: unknown, depth = 0): string {
       lines.push(`${prefix}properties:`);
       for (const [key, propertyValue] of properties) {
         const displayValue = isSensitiveKey(key)
-          ? "[REDACTED]"
+          ? "********"
           : formatValue(propertyValue);
         lines.push(`${prefix}  ${key}: ${displayValue}`);
       }
@@ -236,7 +236,7 @@ function formatUnknownValue(value: unknown, depth = 0): string {
 
 function sensitiveKeyReplacer(key: string, value: unknown): unknown {
   if (key && isSensitiveKey(key)) {
-    return "[REDACTED]";
+    return "********";
   }
   return value;
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -44,7 +44,7 @@ export function filterSensitiveFields(
         if (!key) {
           return value;
         }
-        return isSensitiveKey(key) ? undefined : value;
+        return isSensitiveKey(key) ? "********" : value;
       }),
     );
   } catch {

--- a/src/providers/portkey.ts
+++ b/src/providers/portkey.ts
@@ -59,7 +59,7 @@ export function createPortkeyProvider(
   logDebug(`Portkey base URL: ${config.base_url}`, debug);
   logDebug(`Portkey headers:`, debug);
   for (const [key, value] of Object.entries(headers)) {
-    const maskedValue = isSensitiveKey(key) ? "[REDACTED]" : value;
+    const maskedValue = isSensitiveKey(key) ? "********" : value;
     logDebug(`  ${key}: ${maskedValue}`, debug);
   }
 

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -42,7 +42,7 @@ describe("formatErrorDiagnostics secret redaction", () => {
     expect(output).not.toContain("sk-secret-12345");
     expect(output).not.toContain("super-secret");
     expect(output).not.toContain("camel-case-secret");
-    expect(output).toContain("[REDACTED]");
+    expect(output).toContain("********");
     expect(output).toContain("statusCode");
     expect(output).toContain("403");
   });
@@ -66,7 +66,7 @@ describe("formatErrorDiagnostics secret redaction", () => {
       "very-long-secret-key-that-was-partially-masked",
     );
     expect(output).not.toContain("short-token");
-    expect(output).toContain("[REDACTED]");
+    expect(output).toContain("********");
     expect(output).toContain("application/json");
   });
 

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -120,7 +120,7 @@ describe("security", () => {
 
       expect(filtered).toHaveProperty("type");
       expect(filtered).toHaveProperty("base_url");
-      expect(filtered).not.toHaveProperty("api_key_env");
+      expect(filtered).toHaveProperty("api_key_env", "********");
     });
 
     it("should filter various sensitive field names", () => {
@@ -142,13 +142,13 @@ describe("security", () => {
       expect(filtered).toHaveProperty("type");
       expect(filtered).toHaveProperty("normal_field");
       expect(filtered).toHaveProperty("base_url");
-      expect(filtered).not.toHaveProperty("api_key_env");
-      expect(filtered).not.toHaveProperty("secret_value");
-      expect(filtered).not.toHaveProperty("auth_header");
-      expect(filtered).not.toHaveProperty("password_field");
-      expect(filtered).not.toHaveProperty("access_token");
-      expect(filtered).not.toHaveProperty("apiKey");
-      expect(filtered).not.toHaveProperty("clientSecret");
+      expect(filtered).toHaveProperty("api_key_env", "********");
+      expect(filtered).toHaveProperty("secret_value", "********");
+      expect(filtered).toHaveProperty("auth_header", "********");
+      expect(filtered).toHaveProperty("password_field", "********");
+      expect(filtered).toHaveProperty("access_token", "********");
+      expect(filtered).toHaveProperty("apiKey", "********");
+      expect(filtered).toHaveProperty("clientSecret", "********");
     });
 
     it("should be case-insensitive", () => {
@@ -164,8 +164,8 @@ describe("security", () => {
       );
 
       expect(filtered).toHaveProperty("type");
-      expect(filtered).not.toHaveProperty("API_KEY_ENV");
-      expect(filtered).not.toHaveProperty("SECRET_VALUE");
+      expect(filtered).toHaveProperty("API_KEY_ENV", "********");
+      expect(filtered).toHaveProperty("SECRET_VALUE", "********");
     });
 
     it("should recursively filter sensitive fields in nested objects like headers", () => {
@@ -193,10 +193,10 @@ describe("security", () => {
       const filteredHeaders = filtered.headers as Record<string, string>;
       expect(filteredHeaders).toHaveProperty("Content-Type");
       expect(filteredHeaders).toHaveProperty("x-custom-header");
-      expect(filteredHeaders).not.toHaveProperty("Authorization");
-      expect(filteredHeaders).not.toHaveProperty("x-api-key");
-      expect(filteredHeaders).not.toHaveProperty("x-api-token");
-      expect(filteredHeaders).not.toHaveProperty("credentialRef");
+      expect(filteredHeaders).toHaveProperty("Authorization", "********");
+      expect(filteredHeaders).toHaveProperty("x-api-key", "********");
+      expect(filteredHeaders).toHaveProperty("x-api-token", "********");
+      expect(filteredHeaders).toHaveProperty("credentialRef", "********");
     });
 
     it("should safely filter arrays of objects without leaking", () => {
@@ -213,8 +213,8 @@ describe("security", () => {
       expect(filtered).toHaveProperty("items");
       // biome-ignore lint/suspicious/noExplicitAny: using any for testing dynamic shapes
       const items = filtered.items as any[];
-      expect(items[0]).not.toHaveProperty("api_key");
-      expect(items[1]).not.toHaveProperty("token");
+      expect(items[0]).toHaveProperty("api_key", "********");
+      expect(items[1]).toHaveProperty("token", "********");
       expect(items[1]).toHaveProperty("safe", "value");
     });
   });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Sensitive fields were previously either replaced with `[REDACTED]` or completely dropped (`undefined`) in `filterSensitiveFields`. 
🎯 Impact: Dropping fields makes it difficult to distinguish between a missing configuration and a redacted one in audit logs, potentially hindering security investigations or debugging. Using varying redacted string literals across the codebase decreases consistency.
🔧 Fix: Updated the redaction logic codebase-wide (e.g., in `src/logging.ts`, `src/providers/index.ts`, `src/providers/portkey.ts`) to unconditionally mask all identified sensitive fields with `********`.
✅ Verification: Ran unit tests (`tests/security.test.ts` and `tests/logging.test.ts`) which verify the presence of the `********` value for sensitive keys. Passed `bun run test` and `bun run lint`.

---
*PR created automatically by Jules for task [12014509874616809194](https://jules.google.com/task/12014509874616809194) started by @hongymagic*