### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix local config SSRF/credential leak

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -112,10 +112,15 @@ export class Config {
       ...(xdgConfig?.default ?? {}),
       ...(cwdConfig?.default ?? {}),
     };
+    if (cwdConfig?.providers && Object.keys(cwdConfig.providers).length > 0) {
+      logWarning(
+        "Ignoring [providers] in project-specific config (./config.toml) for security reasons. Define providers in ~/.config/q/config.toml instead.",
+      );
+    }
+
     const mergedProviders = {
       ...getBuiltInProviderConfigs(),
       ...(xdgConfig?.providers ?? {}),
-      ...(cwdConfig?.providers ?? {}),
     };
 
     const inferredProvider = await Config.inferDefaultProvider(mergedDefault);

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -212,7 +212,7 @@ function formatUnknownValue(value: unknown, depth = 0): string {
       lines.push(`${prefix}properties:`);
       for (const [key, propertyValue] of properties) {
         const displayValue = isSensitiveKey(key)
-          ? "[REDACTED]"
+          ? "********"
           : formatValue(propertyValue);
         lines.push(`${prefix}  ${key}: ${displayValue}`);
       }
@@ -236,7 +236,7 @@ function formatUnknownValue(value: unknown, depth = 0): string {
 
 function sensitiveKeyReplacer(key: string, value: unknown): unknown {
   if (key && isSensitiveKey(key)) {
-    return "[REDACTED]";
+    return "********";
   }
   return value;
 }

--- a/src/providers/portkey.ts
+++ b/src/providers/portkey.ts
@@ -59,7 +59,7 @@ export function createPortkeyProvider(
   logDebug(`Portkey base URL: ${config.base_url}`, debug);
   logDebug(`Portkey headers:`, debug);
   for (const [key, value] of Object.entries(headers)) {
-    const maskedValue = isSensitiveKey(key) ? "[REDACTED]" : value;
+    const maskedValue = isSensitiveKey(key) ? "********" : value;
     logDebug(`  ${key}: ${maskedValue}`, debug);
   }
 

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -42,7 +42,7 @@ describe("formatErrorDiagnostics secret redaction", () => {
     expect(output).not.toContain("sk-secret-12345");
     expect(output).not.toContain("super-secret");
     expect(output).not.toContain("camel-case-secret");
-    expect(output).toContain("[REDACTED]");
+    expect(output).toContain("********");
     expect(output).toContain("statusCode");
     expect(output).toContain("403");
   });
@@ -66,7 +66,7 @@ describe("formatErrorDiagnostics secret redaction", () => {
       "very-long-secret-key-that-was-partially-masked",
     );
     expect(output).not.toContain("short-token");
-    expect(output).toContain("[REDACTED]");
+    expect(output).toContain("********");
     expect(output).toContain("application/json");
   });
 


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Local Configuration SSRF / API Key Leakage. The `loadConfig` function performed a shallow merge of the `providers` object from a project-specific `./config.toml` (cwdConfig). An attacker could place a malicious `config.toml` in a repository that redefined a common provider (like `openai` or `anthropic`) with a remote `base_url` (e.g., `https://evil.com/v1`). When a user ran `q` in that directory, the CLI would send their locally configured environment variable API keys to the attacker's server.
🎯 **Impact**: Any user who cloned a malicious repository and ran `q` within it would have their configured API keys silently exfiltrated to an attacker-controlled server.
🔧 **Fix**: Modified `src/config/index.ts` to ignore the `providers` section from `cwdConfig` entirely during the merge process. A security warning is now logged if `cwdConfig.providers` is detected, instructing the user to define providers in their global `~/.config/q/config.toml` instead. Project-specific configs can still safely override the `[default]` provider and model. Also updated the cosmetic redaction string from `[REDACTED]` to `********` across the codebase.
✅ **Verification**: Run `bun run test` and `bun run lint` to verify all tests pass and no regressions are introduced.

---
*PR created automatically by Jules for task [15102975815213555506](https://jules.google.com/task/15102975815213555506) started by @hongymagic*