### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix terminal injection vulnerability and broken CRLF handling

### DIFF
--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -43,6 +43,27 @@ export function sanitizeForClipboard(str: string): string {
 }
 
 /**
+ * Sanitize text for terminal output by stripping ANSI codes and escaping dangerous control characters.
+ * This function escapes C0 control characters, DEL, and C1 control characters (e.g., \b for Backspace)
+ * to prevent terminal output manipulation, while preserving formatting whitespaces like \t, \n, and \r.
+ * @param str The string to sanitize
+ * @returns The sanitized string safe for terminal printing
+ */
+export function sanitizeForTerminal(str: string): string {
+  if (!str) return str;
+
+  const stripped = stripAnsi(str);
+
+  // Preserve safe whitespace: \t (0x09), \n (0x0A), \r (0x0D).
+  // Escape everything else in C0, DEL, C1.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for sanitization
+  return stripped.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, (char) => {
+    const hex = char.charCodeAt(0).toString(16).padStart(2, "0").toUpperCase();
+    return `\\x${hex}`;
+  });
+}
+
+/**
  * Creates a stateful ANSI stripper that handles split chunks.
  */
 export function createAnsiStripper() {

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,6 @@
 import type { LanguageModel } from "ai";
 import { streamText } from "ai";
-import { createAnsiStripper } from "./ansi.ts";
+import { createAnsiStripper, sanitizeForTerminal } from "./ansi.ts";
 import { ProviderError } from "./errors.ts";
 import { buildUserPrompt } from "./prompt.ts";
 
@@ -42,10 +42,10 @@ export async function runQuery(options: RunOptions): Promise<RunResult> {
         onFirstChunk?.();
       }
 
-      // Security: Strip ANSI codes to prevent terminal manipulation
+      // Security: Strip ANSI codes and dangerous control characters to prevent terminal manipulation
       // We keep original text in fullText for the return value (e.g. for clipboard)
       // but sanitize stdout to protect the user's terminal
-      const safeText = stripper(textPart);
+      const safeText = sanitizeForTerminal(stripper(textPart));
       process.stdout.write(safeText);
       fullText += textPart;
     }

--- a/tests/ansi_security.test.ts
+++ b/tests/ansi_security.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { sanitizeForClipboard } from "../src/ansi.ts";
+import { sanitizeForClipboard, sanitizeForTerminal } from "../src/ansi.ts";
 import * as run from "../src/run.ts";
 
 // Mock 'ai' module
@@ -109,5 +109,37 @@ describe("sanitizeForClipboard", () => {
   test("does not escape safe characters", () => {
     const input = "Normal text !@#$%^&*()_+ 1234567890";
     expect(sanitizeForClipboard(input)).toBe(input);
+  });
+});
+
+describe("sanitizeForTerminal", () => {
+  test("strips ANSI escape codes", () => {
+    const input = "\u001b[31mRed\u001b[0m Text";
+    expect(sanitizeForTerminal(input)).toBe("Red Text");
+  });
+
+  test("preserves safe whitespace (newlines, tabs, carriage returns)", () => {
+    const input = "Line 1\n\tIndented\r\nLine 2";
+    expect(sanitizeForTerminal(input)).toBe(input);
+  });
+
+  test("escapes Backspace (\\b) to hex representation", () => {
+    const input = "Line 1\b";
+    expect(sanitizeForTerminal(input)).toBe("Line 1\\x08");
+  });
+
+  test("escapes dangerous C0 control characters to hex representation", () => {
+    const input = "Null\x00 Bell\x07 Escape\x1b";
+    expect(sanitizeForTerminal(input)).toBe("Null\\x00 Bell\\x07 Escape\\x1B");
+  });
+
+  test("escapes DEL character (0x7F)", () => {
+    const input = "Delete\x7f";
+    expect(sanitizeForTerminal(input)).toBe("Delete\\x7F");
+  });
+
+  test("does not escape safe characters", () => {
+    const input = "Normal text !@#$%^&*()_+ 1234567890";
+    expect(sanitizeForTerminal(input)).toBe(input);
   });
 });


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Standard AI LLM outputs directly written to `process.stdout` could contain malicious or extraneous control characters (like `\b`, `\x1B` or C1 controls). While ANSI codes were mostly handled, these additional control characters allowed Terminal Injection logic flaws — enabling terminal over-writing, hiding malicious inputs, or cursor hijacking.
🎯 **Impact:** Allowed untrusted outputs to spoof standard output in the CLI. A previous (failed) internal fix for this over-escaped standard whitespace (specifically Carriage Returns `\r`), causing text streams and standard logging to break via literal `\x0D` insertion.
🔧 **Fix:** Implemented `sanitizeForTerminal` in `src/ansi.ts` explicitly targeting dangerous non-formatting C0 and C1 characters while preserving `\n`, `\t`, and importantly `\r` using a strict regex: `[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]`. Refactored `src/run.ts` to apply this sanitization layer at the explicit stdout integration point, keeping the base `createAnsiStripper` pure to avoid downstream layout sizing side-effects.
✅ **Verification:** Verified via `bun run test` executing `tests/ansi_security.test.ts` where specific control boundary character testing (Backspace `\b` and Carriage Return `\r`) properly asserts. Passed `biome check` to enforce standard coding guidelines.

---
*PR created automatically by Jules for task [16893132659840831948](https://jules.google.com/task/16893132659840831948) started by @hongymagic*