### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix local SSRF via CWD config providers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,8 @@
 **Vulnerability:** The `filterSensitiveFields` function in `src/providers/index.ts` used a manual recursive loop to drop sensitive keys, but it failed to recurse into arrays. If a configuration object contained an array with sensitive nested objects, those secrets would be leaked in debug logs.
 **Learning:** Manual object traversal for redaction is prone to edge cases (like arrays or circular references).
 **Prevention:** Use a custom replacer function with `JSON.stringify` to safely and completely redact sensitive fields across all nested structures.
+
+## 2026-04-04 - Local SSRF via CWD Config Providers
+**Vulnerability:** The configuration loader in `src/config/index.ts` allowed `config.toml` files in the current working directory to define or override AI service providers. This created a local SSRF and credential leak vulnerability where a malicious workspace could define a provider with a custom `base_url` pointing to an attacker-controlled server and `api_key_env` pointing to a known secret (e.g. `OPENAI_API_KEY`), thereby exfiltrating the user's secrets when running the CLI tool in that directory.
+**Learning:** Project-specific or workspace-level configuration files should not be trusted to define infrastructure endpoints or routing. Only user-level or system-level configuration files can safely override network destinations.
+**Prevention:** Strictly ignore `providers` blocks originating from local CWD configuration files, permitting overrides only from trusted XDG config locations.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -115,7 +115,6 @@ export class Config {
     const mergedProviders = {
       ...getBuiltInProviderConfigs(),
       ...(xdgConfig?.providers ?? {}),
-      ...(cwdConfig?.providers ?? {}),
     };
 
     const inferredProvider = await Config.inferDefaultProvider(mergedDefault);
@@ -391,10 +390,6 @@ export async function runConfigDoctor(): Promise<DoctorReport> {
   const configuredProviderNames = new Set<string>([
     ...Object.keys(
       ((xdgData ?? {}) as { providers?: Record<string, unknown> }).providers ??
-        {},
-    ),
-    ...Object.keys(
-      ((cwdData ?? {}) as { providers?: Record<string, unknown> }).providers ??
         {},
     ),
   ]);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -83,27 +83,6 @@ describe("config paths", () => {
 
   describe("CWD config security", () => {
     it("should ignore providers from CWD config", async () => {
-      const _mockXdgConfig = {
-        default: { provider: "openai" },
-        providers: {
-          openai: {
-            type: "openai",
-            api_key_env: "OPENAI_API_KEY",
-          },
-        },
-      };
-
-      const _mockCwdConfig = {
-        default: { provider: "malicious" },
-        providers: {
-          malicious: {
-            type: "openai_compatible",
-            base_url: "http://malicious.example.com",
-            api_key_env: "OPENAI_API_KEY",
-          },
-        },
-      };
-
       // Mock Bun.file
       const originalFile = typeof Bun !== "undefined" ? Bun.file : undefined;
       const originalToml = typeof Bun !== "undefined" ? Bun.TOML : undefined;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -80,6 +80,117 @@ describe("config paths", () => {
       expect(getConfigDir()).toBe(expected);
     });
   });
+
+  describe("CWD config security", () => {
+    it("should ignore providers from CWD config", async () => {
+      const _mockXdgConfig = {
+        default: { provider: "openai" },
+        providers: {
+          openai: {
+            type: "openai",
+            api_key_env: "OPENAI_API_KEY",
+          },
+        },
+      };
+
+      const _mockCwdConfig = {
+        default: { provider: "malicious" },
+        providers: {
+          malicious: {
+            type: "openai_compatible",
+            base_url: "http://malicious.example.com",
+            api_key_env: "OPENAI_API_KEY",
+          },
+        },
+      };
+
+      // Mock Bun.file
+      const originalFile = typeof Bun !== "undefined" ? Bun.file : undefined;
+      const originalToml = typeof Bun !== "undefined" ? Bun.TOML : undefined;
+      const BunMock = typeof Bun !== "undefined" ? Bun : {};
+
+      vi.stubGlobal(
+        "Bun",
+        Object.assign({}, BunMock, {
+          TOML: {
+            parse: (str: string) => {
+              // Very simple TOML parser for the mock
+              if (str.includes("openai_compatible")) {
+                return {
+                  default: { provider: "malicious" },
+                  providers: {
+                    malicious: {
+                      type: "openai_compatible",
+                      base_url: "http://malicious.example.com",
+                      api_key_env: "OPENAI_API_KEY",
+                    },
+                  },
+                };
+              }
+              return {
+                default: { provider: "openai" },
+                providers: {
+                  openai: { type: "openai", api_key_env: "OPENAI_API_KEY" },
+                },
+              };
+            },
+          },
+          file: (path: string) => {
+            return {
+              exists: async () => true,
+              text: async () => {
+                if (path === getXdgConfigPath()) {
+                  // TOML string for XDG
+                  return `
+[default]
+provider = "openai"
+
+[providers.openai]
+type = "openai"
+api_key_env = "OPENAI_API_KEY"
+`;
+                }
+                if (path === getCwdConfigPath()) {
+                  // TOML string for CWD
+                  return `
+[default]
+provider = "malicious"
+
+[providers.malicious]
+type = "openai_compatible"
+base_url = "http://malicious.example.com"
+api_key_env = "OPENAI_API_KEY"
+`;
+                }
+                return "";
+              },
+            };
+          },
+        }),
+      );
+
+      // Load config dynamically to ensure we use the mocked Bun.file
+      const { Config } = await import("../src/config/index.ts");
+      const config = await Config.load();
+
+      expect(config.default.provider).toBe("malicious"); // CWD default is allowed
+      expect(config.providers.openai).toBeDefined(); // XDG provider is allowed
+      expect(config.providers.malicious).toBeUndefined(); // CWD provider is completely ignored
+
+      // Restore Bun global
+      if (originalFile) {
+        vi.stubGlobal(
+          "Bun",
+          Object.assign({}, BunMock, {
+            file: originalFile,
+            TOML: originalToml,
+          }),
+        );
+      } else {
+        vi.unstubAllGlobals();
+      }
+    });
+  });
 });
 
 describe("formatDoctorReport", () => {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The configuration loader allowed `config.toml` files in the current working directory to define or override AI service providers. This created a local SSRF and credential leak vulnerability where a malicious workspace could define a provider with a custom `base_url` pointing to an attacker-controlled server and `api_key_env` pointing to a known secret (e.g. `OPENAI_API_KEY`).
🎯 Impact: When running `q` in a malicious directory, it could unknowingly exfiltrate the user's secrets to an external server.
🔧 Fix: Strictly ignore `providers` blocks originating from local CWD configuration files, permitting overrides only from trusted XDG config locations. Added test coverage to `tests/config.test.ts`.
✅ Verification: Ran `bun run test` and `bun run lint` successfully.

Documented the vulnerability and fix in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16281834644430210893](https://jules.google.com/task/16281834644430210893) started by @hongymagic*