### PR TITLE
🛡️ Sentinel: [HIGH] Fix Terminal Injection via stdout rendering

### DIFF
--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -22,6 +22,27 @@ export function stripAnsi(str: string): string {
 }
 
 /**
+ * Sanitize text for the terminal by stripping ANSI codes and escaping dangerous control characters.
+ * @param str The string to sanitize
+ * @returns The sanitized string safe for terminal output
+ */
+export function sanitizeForTerminal(str: string): string {
+  if (!str) return str;
+
+  // First strip ANSI escape codes
+  const stripped = stripAnsi(str);
+
+  // Replace dangerous control characters with their hex representation
+  // We want to escape C0 control chars (0x00-0x1F), DEL (0x7F), and C1 control chars (0x80-0x9F)
+  // But we want to PRESERVE safe whitespace: \t (0x09), \n (0x0A), \r (0x0D)
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for sanitization
+  return stripped.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, (char) => {
+    const hex = char.charCodeAt(0).toString(16).padStart(2, "0").toUpperCase();
+    return `\\x${hex}`;
+  });
+}
+
+/**
  * Sanitize text for the clipboard by stripping ANSI codes and escaping dangerous control characters.
  * @param str The string to sanitize
  * @returns The sanitized string safe for clipboard insertion

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,6 @@
 import type { LanguageModel } from "ai";
 import { streamText } from "ai";
-import { createAnsiStripper } from "./ansi.ts";
+import { createAnsiStripper, sanitizeForTerminal } from "./ansi.ts";
 import { ProviderError } from "./errors.ts";
 import { buildUserPrompt } from "./prompt.ts";
 
@@ -45,7 +45,7 @@ export async function runQuery(options: RunOptions): Promise<RunResult> {
       // Security: Strip ANSI codes to prevent terminal manipulation
       // We keep original text in fullText for the return value (e.g. for clipboard)
       // but sanitize stdout to protect the user's terminal
-      const safeText = stripper(textPart);
+      const safeText = sanitizeForTerminal(stripper(textPart));
       process.stdout.write(safeText);
       fullText += textPart;
     }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Terminal Injection via ANSI escape sequence rendering in stdout.
🎯 Impact: Untrusted text or prompt injections could send ANSI control sequences to modify the user's terminal appearance or trigger malicious interactions.
🔧 Fix: Implemented `sanitizeForTerminal` to sanitize stdout chunks exactly like the clipboard sanitizer does, stripping ANSI codes and safely escaping control characters.
✅ Verification: Ran `bun test` and verified the fix correctly passes standard security test cases.

---
*PR created automatically by Jules for task [2318807695783549814](https://jules.google.com/task/2318807695783549814) started by @hongymagic*