### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Terminal Injection vulnerability by fully sanitizing stdout

### DIFF
--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -26,6 +26,24 @@ export function stripAnsi(str: string): string {
  * @param str The string to sanitize
  * @returns The sanitized string safe for clipboard insertion
  */
+export function sanitizeForTerminal(str: string): string {
+  if (!str) return str;
+
+  // Replace dangerous control characters with their hex representation
+  // We want to escape C0 control chars (0x00-0x1F), DEL (0x7F), and C1 control chars (0x80-0x9F)
+  // But we want to PRESERVE safe whitespace: \t (0x09), \n (0x0A), \r (0x0D)
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for sanitization
+  return str.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, (char) => {
+    const hex = char.charCodeAt(0).toString(16).padStart(2, "0").toUpperCase();
+    return `\\x${hex}`;
+  });
+}
+
+/**
+ * Sanitize text for the clipboard by stripping ANSI codes and escaping dangerous control characters.
+ * @param str The string to sanitize
+ * @returns The sanitized string safe for clipboard insertion
+ */
 export function sanitizeForClipboard(str: string): string {
   if (!str) return str;
 
@@ -33,13 +51,7 @@ export function sanitizeForClipboard(str: string): string {
   const stripped = stripAnsi(str);
 
   // Then replace dangerous control characters with their hex representation
-  // We want to escape C0 control chars (0x00-0x1F), DEL (0x7F), and C1 control chars (0x80-0x9F)
-  // But we want to PRESERVE safe whitespace: \t (0x09), \n (0x0A), \r (0x0D)
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for sanitization
-  return stripped.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, (char) => {
-    const hex = char.charCodeAt(0).toString(16).padStart(2, "0").toUpperCase();
-    return `\\x${hex}`;
-  });
+  return sanitizeForTerminal(stripped);
 }
 
 /**

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,6 @@
 import type { LanguageModel } from "ai";
 import { streamText } from "ai";
-import { createAnsiStripper } from "./ansi.ts";
+import { createAnsiStripper, sanitizeForTerminal } from "./ansi.ts";
 import { ProviderError } from "./errors.ts";
 import { buildUserPrompt } from "./prompt.ts";
 
@@ -45,7 +45,7 @@ export async function runQuery(options: RunOptions): Promise<RunResult> {
       // Security: Strip ANSI codes to prevent terminal manipulation
       // We keep original text in fullText for the return value (e.g. for clipboard)
       // but sanitize stdout to protect the user's terminal
-      const safeText = stripper(textPart);
+      const safeText = sanitizeForTerminal(stripper(textPart));
       process.stdout.write(safeText);
       fullText += textPart;
     }

--- a/tests/ansi_security.test.ts
+++ b/tests/ansi_security.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { sanitizeForClipboard } from "../src/ansi.ts";
+import { sanitizeForClipboard, sanitizeForTerminal } from "../src/ansi.ts";
 import * as run from "../src/run.ts";
 
 // Mock 'ai' module
@@ -46,6 +46,31 @@ describe("runQuery Security", () => {
     expect(calls).toContain("echo safe");
   });
 
+  test("escapes dangerous control characters from stdout but keeps them in returned text", async () => {
+    mockStreamText.mockReturnValue({
+      textStream: (async function* () {
+        yield "echo ";
+        yield "danger\x08"; // Backspace
+      })(),
+    });
+
+    const writeSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    const result = await run.runQuery({
+      // @ts-expect-error - mocking model
+      model: {},
+      query: "test",
+      systemPrompt: "test",
+    });
+
+    expect(result.text).toBe("echo danger\x08");
+
+    const calls = writeSpy.mock.calls.map((c) => c[0]).join("");
+    expect(calls).toContain("echo danger\\x08");
+  });
+
   test("handles split ANSI sequences across chunks", async () => {
     mockStreamText.mockReturnValue({
       textStream: (async function* () {
@@ -74,6 +99,35 @@ describe("runQuery Security", () => {
 
     // return value should have codes
     expect(result.text).toBe("Start\u001b[31mRed\u001b[0m");
+  });
+});
+
+describe("sanitizeForTerminal", () => {
+  test("preserves safe whitespace (newlines, tabs, carriage returns)", () => {
+    const input = "Line 1\n\tIndented\r\nLine 2";
+    expect(sanitizeForTerminal(input)).toBe(input);
+  });
+
+  test("escapes dangerous C0 control characters to hex representation", () => {
+    const input = "Null\x00 Bell\x07 Backspace\x08 Escape\x1b";
+    expect(sanitizeForTerminal(input)).toBe(
+      "Null\\x00 Bell\\x07 Backspace\\x08 Escape\\x1B",
+    );
+  });
+
+  test("escapes DEL character (0x7F)", () => {
+    const input = "Delete\x7f";
+    expect(sanitizeForTerminal(input)).toBe("Delete\\x7F");
+  });
+
+  test("escapes C1 control character U+009B (CSI)", () => {
+    const input = "CSI\u009B Test";
+    expect(sanitizeForTerminal(input)).toBe("CSI\\x9B Test");
+  });
+
+  test("does not escape safe characters", () => {
+    const input = "Normal text !@#$%^&*()_+ 1234567890";
+    expect(sanitizeForTerminal(input)).toBe(input);
   });
 });
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Terminal Injection risk via LLM output. The application previously stripped ANSI codes from `stdout` but did not escape dangerous C0/C1 control characters (like `\x08` Backspace, `\x07` Bell, or `\x9B` CSI) which could be used to manipulate the terminal visually or, depending on terminal software, trigger unintended actions when rendering.
🎯 Impact: A malicious model output could overwrite legitimate text on the user's console or abuse terminal escape bugs by injecting raw control characters into stdout.
🔧 Fix: Extracted the robust control-character escaping logic (which protects against C0/C1 controls while preserving safe whitespace) into a new `sanitizeForTerminal` utility, and applied it to all streamed stdout chunks.
✅ Verification: Added comprehensive unit tests in `ansi_security.test.ts` to verify `sanitizeForTerminal` functionality and ensure `runQuery` correctly sanitizes stdout. Run `bun run test` to verify.

---
*PR created automatically by Jules for task [14160276199712875418](https://jules.google.com/task/14160276199712875418) started by @hongymagic*