### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix local config SSRF and credential leak

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,8 @@
 **Vulnerability:** The `filterSensitiveFields` function in `src/providers/index.ts` used a manual recursive loop to drop sensitive keys, but it failed to recurse into arrays. If a configuration object contained an array with sensitive nested objects, those secrets would be leaked in debug logs.
 **Learning:** Manual object traversal for redaction is prone to edge cases (like arrays or circular references).
 **Prevention:** Use a custom replacer function with `JSON.stringify` to safely and completely redact sensitive fields across all nested structures.
+
+## 2026-04-07 - Local Config SSRF and Credential Leak
+**Vulnerability:** The configuration loader merged the `providers` object from a local `./config.toml` file into the main configuration. This allowed a malicious repository to override the `base_url` for built-in providers (e.g. pointing them to a local metadata service at `169.254.169.254`), exposing user API keys or triggering SSRF attacks when `q` was run in that directory.
+**Learning:** Local, project-specific configuration files must never be allowed to override critical security or network settings (like where credentials are sent or what endpoints are hit).
+**Prevention:** Only permit global (user-level) configuration to define or modify service providers. Project-level configuration should be restricted to non-sensitive defaults (like `default.provider`).

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -115,7 +115,6 @@ export class Config {
     const mergedProviders = {
       ...getBuiltInProviderConfigs(),
       ...(xdgConfig?.providers ?? {}),
-      ...(cwdConfig?.providers ?? {}),
     };
 
     const inferredProvider = await Config.inferDefaultProvider(mergedDefault);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The configuration system previously merged the `providers` object from a local `./config.toml` file into the active configuration. If a user ran `q` in a malicious or compromised repository, an attacker could redefine `base_url` for a given provider (like `google` or `openai`), pointing it to an attacker-controlled endpoint or an internal metadata server (`169.254.169.254`). 
🎯 **Impact:** When a request was made, the user's global API keys for that provider would be sent to the malicious endpoint, leading to complete credential theft. It could also trigger local SSRF by proxying requests.
🔧 **Fix:** Modified `Config.load()` in `src/config/index.ts` to drop the `providers` key from `cwdConfig`. Local configuration can now only dictate non-sensitive default values.
✅ **Verification:** A test script confirming that local base_url overrides are safely ignored has been successfully executed, and all unit tests passed. Also recorded the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [996837089129364096](https://jules.google.com/task/996837089129364096) started by @hongymagic*