### PR TITLE
🛡️ Sentinel: [HIGH] Fix terminal injection via control characters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,8 @@
 **Vulnerability:** The `filterSensitiveFields` function in `src/providers/index.ts` used a manual recursive loop to drop sensitive keys, but it failed to recurse into arrays. If a configuration object contained an array with sensitive nested objects, those secrets would be leaked in debug logs.
 **Learning:** Manual object traversal for redaction is prone to edge cases (like arrays or circular references).
 **Prevention:** Use a custom replacer function with `JSON.stringify` to safely and completely redact sensitive fields across all nested structures.
+
+## 2026-04-13 - Terminal Injection via Control Characters
+**Vulnerability:** While ANSI codes were stripped from AI model output written to stdout, dangerous C0/C1 control characters (such as Backspace `\x08` or Bell `\x07`) could still be emitted, allowing for terminal output manipulation.
+**Learning:** Terminal sanitization requires more than just stripping ANSI escape sequences; standalone control characters can also be used maliciously.
+**Prevention:** Explicitly sanitize dangerous C0 and C1 control characters in text emitted to the terminal by escaping them to their hex representation, while preserving safe formatting characters.

--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -22,6 +22,25 @@ export function stripAnsi(str: string): string {
 }
 
 /**
+ * Sanitize text for terminal output by escaping dangerous control characters.
+ * Useful to prevent terminal injection attacks after ANSI stripping.
+ * @param str The string to sanitize
+ * @returns The sanitized string safe for terminal output
+ */
+export function sanitizeForTerminal(str: string): string {
+  if (!str) return str;
+
+  // Replace dangerous control characters with their hex representation
+  // We want to escape C0 control chars (0x00-0x1F), DEL (0x7F), and C1 control chars (0x80-0x9F)
+  // But we want to PRESERVE safe whitespace: \t (0x09), \n (0x0A), \r (0x0D)
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for sanitization
+  return str.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, (char) => {
+    const hex = char.charCodeAt(0).toString(16).padStart(2, "0").toUpperCase();
+    return `\\x${hex}`;
+  });
+}
+
+/**
  * Sanitize text for the clipboard by stripping ANSI codes and escaping dangerous control characters.
  * @param str The string to sanitize
  * @returns The sanitized string safe for clipboard insertion
@@ -32,14 +51,8 @@ export function sanitizeForClipboard(str: string): string {
   // First strip ANSI escape codes
   const stripped = stripAnsi(str);
 
-  // Then replace dangerous control characters with their hex representation
-  // We want to escape C0 control chars (0x00-0x1F), DEL (0x7F), and C1 control chars (0x80-0x9F)
-  // But we want to PRESERVE safe whitespace: \t (0x09), \n (0x0A), \r (0x0D)
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for sanitization
-  return stripped.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, (char) => {
-    const hex = char.charCodeAt(0).toString(16).padStart(2, "0").toUpperCase();
-    return `\\x${hex}`;
-  });
+  // Then sanitize dangerous control characters
+  return sanitizeForTerminal(stripped);
 }
 
 /**

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,6 @@
 import type { LanguageModel } from "ai";
 import { streamText } from "ai";
-import { createAnsiStripper } from "./ansi.ts";
+import { createAnsiStripper, sanitizeForTerminal } from "./ansi.ts";
 import { ProviderError } from "./errors.ts";
 import { buildUserPrompt } from "./prompt.ts";
 
@@ -45,7 +45,7 @@ export async function runQuery(options: RunOptions): Promise<RunResult> {
       // Security: Strip ANSI codes to prevent terminal manipulation
       // We keep original text in fullText for the return value (e.g. for clipboard)
       // but sanitize stdout to protect the user's terminal
-      const safeText = stripper(textPart);
+      const safeText = sanitizeForTerminal(stripper(textPart));
       process.stdout.write(safeText);
       fullText += textPart;
     }

--- a/tests/ansi_security.test.ts
+++ b/tests/ansi_security.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { sanitizeForClipboard } from "../src/ansi.ts";
+import { sanitizeForClipboard, sanitizeForTerminal } from "../src/ansi.ts";
 import * as run from "../src/run.ts";
 
 // Mock 'ai' module
@@ -74,6 +74,35 @@ describe("runQuery Security", () => {
 
     // return value should have codes
     expect(result.text).toBe("Start\u001b[31mRed\u001b[0m");
+  });
+});
+
+describe("sanitizeForTerminal", () => {
+  test("escapes dangerous C0 control characters to hex representation", () => {
+    const input = "Null\x00 Bell\x07 Backspace\x08 Escape\x1b";
+    expect(sanitizeForTerminal(input)).toBe(
+      "Null\\x00 Bell\\x07 Backspace\\x08 Escape\\x1B",
+    );
+  });
+
+  test("preserves safe whitespace (newlines, tabs, carriage returns)", () => {
+    const input = "Line 1\n\tIndented\r\nLine 2";
+    expect(sanitizeForTerminal(input)).toBe(input);
+  });
+
+  test("escapes DEL character (0x7F)", () => {
+    const input = "Delete\x7f";
+    expect(sanitizeForTerminal(input)).toBe("Delete\\x7F");
+  });
+
+  test("escapes C1 control character U+009B (CSI)", () => {
+    const input = "CSI\u009B Test";
+    expect(sanitizeForTerminal(input)).toBe("CSI\\x9B Test");
+  });
+
+  test("does not escape safe characters", () => {
+    const input = "Normal text !@#$%^&*()_+ 1234567890";
+    expect(sanitizeForTerminal(input)).toBe(input);
   });
 });
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Terminal output manipulation could still occur because standalone dangerous C0/C1 control characters were not sanitized before being printed to stdout, even though ANSI sequences were stripped.
🎯 Impact: A malicious model or prompt injection could inject control characters to manipulate the terminal presentation (e.g., hiding text, ringing the bell).
🔧 Fix: Extracted the control character sanitization logic from `sanitizeForClipboard` into a reusable `sanitizeForTerminal` function and applied it to text written to stdout in `runQuery`.
✅ Verification: Confirmed via unit tests in `ansi_security.test.ts` and manually verified proper terminal output behavior.

---
*PR created automatically by Jules for task [5556609789309700149](https://jules.google.com/task/5556609789309700149) started by @hongymagic*