### PR TITLE
🛡️ Sentinel: [HIGH] Fix Terminal Injection via Control Characters

### DIFF
--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -22,6 +22,27 @@ export function stripAnsi(str: string): string {
 }
 
 /**
+ * Sanitize text for the terminal by stripping ANSI codes and escaping dangerous control characters.
+ * @param str The string to sanitize
+ * @returns The sanitized string safe for terminal output
+ */
+export function sanitizeForTerminal(str: string): string {
+  if (!str) return str;
+
+  // First strip ANSI escape codes
+  const stripped = stripAnsi(str);
+
+  // Then replace dangerous control characters with their hex representation
+  // We want to escape C0 control chars (0x00-0x1F), DEL (0x7F), and C1 control chars (0x80-0x9F)
+  // But we want to PRESERVE safe whitespace: \t (0x09), \n (0x0A), \r (0x0D)
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: Intentionally matching control characters for sanitization
+  return stripped.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, (char) => {
+    const hex = char.charCodeAt(0).toString(16).padStart(2, "0").toUpperCase();
+    return `\\x${hex}`;
+  });
+}
+
+/**
  * Sanitize text for the clipboard by stripping ANSI codes and escaping dangerous control characters.
  * @param str The string to sanitize
  * @returns The sanitized string safe for clipboard insertion

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,6 @@
 import type { LanguageModel } from "ai";
 import { streamText } from "ai";
-import { createAnsiStripper } from "./ansi.ts";
+import { createAnsiStripper, sanitizeForTerminal } from "./ansi.ts";
 import { ProviderError } from "./errors.ts";
 import { buildUserPrompt } from "./prompt.ts";
 
@@ -45,7 +45,7 @@ export async function runQuery(options: RunOptions): Promise<RunResult> {
       // Security: Strip ANSI codes to prevent terminal manipulation
       // We keep original text in fullText for the return value (e.g. for clipboard)
       // but sanitize stdout to protect the user's terminal
-      const safeText = stripper(textPart);
+      const safeText = sanitizeForTerminal(stripper(textPart));
       process.stdout.write(safeText);
       fullText += textPart;
     }

--- a/tests/ansi_security.test.ts
+++ b/tests/ansi_security.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { sanitizeForClipboard } from "../src/ansi.ts";
+import { sanitizeForClipboard, sanitizeForTerminal } from "../src/ansi.ts";
 import * as run from "../src/run.ts";
 
 // Mock 'ai' module
@@ -74,6 +74,69 @@ describe("runQuery Security", () => {
 
     // return value should have codes
     expect(result.text).toBe("Start\u001b[31mRed\u001b[0m");
+  });
+
+  test("strips dangerous control characters from stdout but keeps them in returned text", async () => {
+    mockStreamText.mockReturnValue({
+      textStream: (async function* () {
+        yield "Start";
+        yield "\x08"; // Backspace
+        yield "safe";
+        yield "\x00"; // Null
+      })(),
+    });
+
+    const writeSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    const result = await run.runQuery({
+      // @ts-expect-error - mocking model
+      model: {},
+      query: "test",
+      systemPrompt: "test",
+    });
+
+    // Check what was returned - SHOULD CONTAIN CONTROL CHARS
+    expect(result.text).toBe("Start\x08safe\x00");
+
+    // Check what was written to stdout - SHOULD NOT CONTAIN CONTROL CHARS
+    const calls = writeSpy.mock.calls.map((c) => c[0]).join("");
+    expect(calls).toBe("Start\\x08safe\\x00\n");
+  });
+});
+
+describe("sanitizeForTerminal", () => {
+  test("strips ANSI escape codes", () => {
+    const input = "\u001b[31mRed\u001b[0m Text";
+    expect(sanitizeForTerminal(input)).toBe("Red Text");
+  });
+
+  test("preserves safe whitespace (newlines, tabs, carriage returns)", () => {
+    const input = "Line 1\n\tIndented\r\nLine 2";
+    expect(sanitizeForTerminal(input)).toBe(input);
+  });
+
+  test("escapes dangerous C0 control characters to hex representation", () => {
+    const input = "Null\x00 Bell\x07 Backspace\x08 Escape\x1b";
+    expect(sanitizeForTerminal(input)).toBe(
+      "Null\\x00 Bell\\x07 Backspace\\x08 Escape\\x1B",
+    );
+  });
+
+  test("escapes DEL character (0x7F)", () => {
+    const input = "Delete\x7f";
+    expect(sanitizeForTerminal(input)).toBe("Delete\\x7F");
+  });
+
+  test("escapes C1 control character U+009B (CSI)", () => {
+    const input = "CSI\u009B Test";
+    expect(sanitizeForTerminal(input)).toBe("CSI\\x9B Test");
+  });
+
+  test("does not escape safe characters", () => {
+    const input = "Normal text !@#$%^&*()_+ 1234567890";
+    expect(sanitizeForTerminal(input)).toBe(input);
   });
 });
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Terminal Escape Sequence Injection. The CLI writes AI-generated text directly to standard output after only stripping ANSI sequences. However, raw control characters (like Null `\x00`, Backspace `\x08`, or Escape `\x1B`) could still be present. If an attacker uses a malicious model or injects prompt input to generate these bytes, they might silently manipulate the user's terminal, hide text, or potentially trigger terminal emulator vulnerabilities.
🎯 Impact: Attackers could manipulate what the user sees on their terminal or exploit bugs in the terminal emulator, undermining the integrity of the CLI session.
🔧 Fix: Added a `sanitizeForTerminal` function in `src/ansi.ts` that not only strips ANSI sequences but also escapes dangerous C0 (0x00-0x1F) and C1 (0x80-0x9F) control characters and DEL (0x7F) into literal hex (e.g., `\x08`). Safe whitespace (`\n`, `\t`, `\r`) is preserved. The `stdout.write` call in `src/run.ts` now uses this sanitizer.
✅ Verification: Ensure the test suite passes (specifically `bun run test tests/ansi_security.test.ts`), which covers stripping and escaping behavior for terminal output without affecting clipboard return values.

---
*PR created automatically by Jules for task [5880393562675862174](https://jules.google.com/task/5880393562675862174) started by @hongymagic*