### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix provider injection via local config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,7 @@
 **Vulnerability:** The `filterSensitiveFields` function in `src/providers/index.ts` used a manual recursive loop to drop sensitive keys, but it failed to recurse into arrays. If a configuration object contained an array with sensitive nested objects, those secrets would be leaked in debug logs.
 **Learning:** Manual object traversal for redaction is prone to edge cases (like arrays or circular references).
 **Prevention:** Use a custom replacer function with `JSON.stringify` to safely and completely redact sensitive fields across all nested structures.
+## 2026-04-24 - Provider Injection via Local Config (SSRF)
+**Vulnerability:** The application allowed project-level (`./config.toml`) configuration files to define or override service providers. An attacker could commit a malicious config file that points an AI provider base URL to an internal server, leading to Server-Side Request Forgery (SSRF) when the CLI is run in that directory.
+**Learning:** Automatically trusting and loading complex configuration objects (like service providers or API URLs) from the Current Working Directory (CWD) is dangerous because it elevates the trust of potentially unreviewed project files to the level of the user's global execution environment.
+**Prevention:** Restrict provider definitions and overrides to the user's global XDG configuration file. CWD configuration files should only be allowed to modify safe, non-executable options (like default models or flags).

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -115,7 +115,9 @@ export class Config {
     const mergedProviders = {
       ...getBuiltInProviderConfigs(),
       ...(xdgConfig?.providers ?? {}),
-      ...(cwdConfig?.providers ?? {}),
+      // Security: CWD config is intentionally not allowed to define providers.
+      // This prevents local SSRF vulnerabilities where an attacker could commit a
+      // custom config file to point a provider at an internal server.
     };
 
     const inferredProvider = await Config.inferDefaultProvider(mergedDefault);
@@ -391,10 +393,6 @@ export async function runConfigDoctor(): Promise<DoctorReport> {
   const configuredProviderNames = new Set<string>([
     ...Object.keys(
       ((xdgData ?? {}) as { providers?: Record<string, unknown> }).providers ??
-        {},
-    ),
-    ...Object.keys(
-      ((cwdData ?? {}) as { providers?: Record<string, unknown> }).providers ??
         {},
     ),
   ]);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -82,6 +82,36 @@ describe("config paths", () => {
   });
 });
 
+describe("Config", () => {
+  describe("load", () => {
+    it("should ignore providers from cwd config", async () => {
+      const { Config } = await import("../src/config/index.ts");
+      const tryLoadFileSpy = vi.spyOn(Config as any, "tryLoadFile");
+      tryLoadFileSpy.mockResolvedValueOnce({
+        default: { provider: "anthropic" },
+        providers: {
+          anthropic: { type: "anthropic", model: "claude-3-5-sonnet" },
+        },
+      }); // XDG config
+      tryLoadFileSpy.mockResolvedValueOnce({
+        default: { copy: true },
+        providers: {
+          malicious: { type: "openai_compatible", base_url: "http://internal" },
+        },
+      }); // CWD config
+
+      const config = await Config.load();
+
+      expect(config.default.provider).toBe("anthropic");
+      expect(config.default.copy).toBe(true); // default properties are still merged
+      expect(config.providers.anthropic).toBeDefined();
+      expect(config.providers.malicious).toBeUndefined(); // providers from cwd are ignored
+
+      tryLoadFileSpy.mockRestore();
+    });
+  });
+});
+
 describe("formatDoctorReport", () => {
   function makeReport(overrides: Partial<DoctorReport> = {}): DoctorReport {
     return {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The application allowed project-level (`./config.toml`) configuration files to define or override service providers. An attacker could commit a malicious config file that points an AI provider base URL to an internal server.
🎯 **Impact:** Server-Side Request Forgery (SSRF) when the CLI is run in a directory containing a malicious config file, potentially exposing internal services or exfiltrating tokens.
🔧 **Fix:** Restricted provider definitions strictly to the user's global XDG configuration. The CWD configuration is no longer allowed to define or override providers, though it can still define safe project-level defaults.
✅ **Verification:** Added unit tests verifying that `cwdConfig.providers` is ignored during config loading. Run `bun run test` to verify.

---
*PR created automatically by Jules for task [11011576205704873971](https://jules.google.com/task/11011576205704873971) started by @hongymagic*