### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix local SSRF in configuration files

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,8 @@
 **Vulnerability:** The `filterSensitiveFields` function in `src/providers/index.ts` used a manual recursive loop to drop sensitive keys, but it failed to recurse into arrays. If a configuration object contained an array with sensitive nested objects, those secrets would be leaked in debug logs.
 **Learning:** Manual object traversal for redaction is prone to edge cases (like arrays or circular references).
 **Prevention:** Use a custom replacer function with `JSON.stringify` to safely and completely redact sensitive fields across all nested structures.
+
+## 2026-03-12 - Local SSRF via Project-Specific Configs
+**Vulnerability:** The configuration loader merged provider configurations from the current working directory's config file (`./config.toml`). This allowed a malicious local repository to override a provider's `base_url` to point to a local service or a malicious endpoint, potentially leading to local SSRF or credential exfiltration when a user ran the CLI tool within that directory.
+**Learning:** Project-specific configuration files should never be trusted to define or override critical service parameters like API endpoints or authentication mechanisms. Such settings must exclusively reside in trusted, user-level configuration directories.
+**Prevention:** Restrict the loading of provider configurations to global/user-level config files (e.g., XDG config home) and ignore provider definitions in project-local configuration files.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -115,7 +115,6 @@ export class Config {
     const mergedProviders = {
       ...getBuiltInProviderConfigs(),
       ...(xdgConfig?.providers ?? {}),
-      ...(cwdConfig?.providers ?? {}),
     };
 
     const inferredProvider = await Config.inferDefaultProvider(mergedDefault);
@@ -391,10 +390,6 @@ export async function runConfigDoctor(): Promise<DoctorReport> {
   const configuredProviderNames = new Set<string>([
     ...Object.keys(
       ((xdgData ?? {}) as { providers?: Record<string, unknown> }).providers ??
-        {},
-    ),
-    ...Object.keys(
-      ((cwdData ?? {}) as { providers?: Record<string, unknown> }).providers ??
         {},
     ),
   ]);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The configuration loader incorrectly merged provider configurations from the current working directory's config file (`./config.toml`). This allowed a malicious local repository to override a provider's `base_url` to point to a local service or a malicious endpoint, potentially leading to local SSRF or credential exfiltration when a user ran the CLI tool within that directory.
🎯 Impact: Attackers could gain unauthorized access to internal services or steal user API keys by tricking them into running the CLI in a malicious directory.
🔧 Fix: Removed the code that loads and merges `cwdConfig.providers` in `Config.load()`, and updated `runConfigDoctor()` to match, enforcing that providers can only be defined in the trusted XDG config directory.
✅ Verification: `bun run test` passes, and the manual SSRF attempt would no longer override the global `base_url`.

---
*PR created automatically by Jules for task [17860738303232879514](https://jules.google.com/task/17860738303232879514) started by @hongymagic*