### PR TITLE
🛡️ Sentinel: [HIGH] Fix terminal injection via ST sequence bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,8 @@
 **Vulnerability:** The `filterSensitiveFields` function in `src/providers/index.ts` used a manual recursive loop to drop sensitive keys, but it failed to recurse into arrays. If a configuration object contained an array with sensitive nested objects, those secrets would be leaked in debug logs.
 **Learning:** Manual object traversal for redaction is prone to edge cases (like arrays or circular references).
 **Prevention:** Use a custom replacer function with `JSON.stringify` to safely and completely redact sensitive fields across all nested structures.
+
+## 2026-05-26 - Terminal Injection via ST (String Terminator) Sequences
+**Vulnerability:** The ANSI stripping logic only supported `\u0007` (Bell) as the terminator for Operating System Command (OSC) sequences. It failed to support the alternative ANSI standard terminator `\u001b\` (String Terminator, or ST). An attacker could bypass output sanitization by terminating a malicious hyperlink or other OSC sequence with `\u001b\`, leading to terminal injection.
+**Learning:** ANSI standards are complex and support multiple escape sequences. Relying on partial implementations (like only supporting BEL) leaves gaps that can be exploited for terminal injection when the output contains untrusted AI generation. Stateful stream chunking makes partial matching especially difficult if the terminator spans chunk boundaries.
+**Prevention:** Update ANSI removal regular expressions to fully match standard OSC terminators, specifically `(?:\u0007|\u001B\\)`. Ensure stream-chunk buffering logic correctly identifies the starts and ends of sequences, even when the terminator itself is a multi-character escape sequence.

--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -2,7 +2,7 @@
 // eslint-disable-next-line no-control-regex
 const ANSI_REGEX = new RegExp(
   [
-    "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
+    "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?(?:\\u0007|\\u001B\\\\))",
     "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))",
   ].join("|"),
   "g",
@@ -59,10 +59,31 @@ export function createAnsiStripper() {
 
     // If the buffer ends with a partial ANSI sequence (starts with ESC), keep it in buffer
     // ESC is \u001B or \u009B
-    const lastEscIndex = Math.max(
+    let lastEscIndex = Math.max(
       buffer.lastIndexOf("\u001B"),
       buffer.lastIndexOf("\u009B"),
     );
+
+    // If the last ESC is part of an ST terminator (\u001B\\), it's not the start
+    // of an incomplete sequence, it's the end of an OSC sequence. We should look
+    // for the ESC that precedes it to find the actual start of a potentially
+    // incomplete sequence.
+    if (
+      lastEscIndex !== -1 &&
+      buffer.slice(lastEscIndex, lastEscIndex + 2) === "\u001B\\"
+    ) {
+      let checkIndex = lastEscIndex;
+      while (
+        checkIndex !== -1 &&
+        buffer.slice(checkIndex, checkIndex + 2) === "\u001B\\"
+      ) {
+        checkIndex = Math.max(
+          buffer.lastIndexOf("\u001B", checkIndex - 1),
+          buffer.lastIndexOf("\u009B", checkIndex - 1),
+        );
+      }
+      lastEscIndex = checkIndex;
+    }
 
     if (lastEscIndex !== -1) {
       // Check if this looks like an incomplete sequence

--- a/tests/ansi.test.ts
+++ b/tests/ansi.test.ts
@@ -35,3 +35,13 @@ test("createAnsiStripper handles alternating plain text and ANSI chunks", () => 
   expect(stripper("\u001b[33myellow\u001b[0m")).toBe("yellow");
   expect(stripper("final")).toBe("final");
 });
+
+test("createAnsiStripper handles ST sequences", () => {
+  const stripper = createAnsiStripper();
+  // String terminated with ST sequence (\u001b\)
+  const stSequence =
+    "\u001b]8;;http://example.com\u001b\\Link\u001b]8;;\u001b\\";
+
+  // Depending on whether it splits or is in one chunk, the result should be just the link text
+  expect(stripper(stSequence)).toBe("Link");
+});


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Terminal Injection via ST (String Terminator) Sequences bypassing `stripAnsi` filter
🎯 **Impact:** An attacker could craft prompt injections that result in the AI emitting an OSC sequence (such as an invisible, clickable hyperlink to a malicious site) terminated with `\u001b\`. Because the filter didn't recognize ST, the malicious link would be rendered in the victim's terminal unstripped.
🔧 **Fix:** 
1. Updated `ANSI_REGEX` in `src/ansi.ts` to recognize `(?:\u0007|\u001B\\)` as valid OSC terminators.
2. Fixed a bug in `createAnsiStripper` where it failed to find the start of an incomplete sequence if the buffer ended with `\u001b\`. The logic now iterates backwards past contiguous ST terminators.
✅ **Verification:** Added dedicated ST test cases in `tests/ansi.test.ts`. All existing suite tests and formatting checks pass securely.

---
*PR created automatically by Jules for task [17731770410998614750](https://jules.google.com/task/17731770410998614750) started by @hongymagic*