### PR TITLE
🛡️ Sentinel: [security improvement] Add bearer, session, jwt, and cookie to sensitive key redaction

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,8 @@
 **Vulnerability:** The `filterSensitiveFields` function in `src/providers/index.ts` used a manual recursive loop to drop sensitive keys, but it failed to recurse into arrays. If a configuration object contained an array with sensitive nested objects, those secrets would be leaked in debug logs.
 **Learning:** Manual object traversal for redaction is prone to edge cases (like arrays or circular references).
 **Prevention:** Use a custom replacer function with `JSON.stringify` to safely and completely redact sensitive fields across all nested structures.
+
+## 2026-06-23 - Defense in Depth: Expanded Sensitive Key Redaction
+**Vulnerability:** The `SENSITIVE_KEY_PATTERNS` list used to detect and redact sensitive keys in logs was missing several common authentication and session tokens, such as `bearer`, `session`, `jwt`, and `cookie`. If these keys appeared in configuration or error objects, they would not be redacted and could leak sensitive information into logs.
+**Learning:** Security redaction lists should be comprehensive and account for modern web authentication patterns, not just basic keys and secrets.
+**Prevention:** Regularly review and expand sensitive key pattern lists to ensure new or alternative authentication tokens are caught.

--- a/src/sensitive.ts
+++ b/src/sensitive.ts
@@ -8,6 +8,10 @@ const SENSITIVE_KEY_PATTERNS = [
   "auth",
   "credential",
   "authorization",
+  "bearer",
+  "session",
+  "jwt",
+  "cookie",
 ];
 
 export function isSensitiveKey(key: string): boolean {


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: The `SENSITIVE_KEY_PATTERNS` list used to detect and redact sensitive keys in logs was missing several common authentication and session tokens, such as `bearer`, `session`, `jwt`, and `cookie`.
🎯 Impact: If these keys appeared in configuration or error objects, they would not be redacted and could leak sensitive information into logs.
🔧 Fix: Added "bearer", "session", "jwt", and "cookie" to the `SENSITIVE_KEY_PATTERNS` list in `src/sensitive.ts` to ensure these common authentication and session tokens are properly redacted.
✅ Verification: Ensure the unit tests pass (`bun run test`) and no sensitive information is leaked in logs.

---
*PR created automatically by Jules for task [4907987034879649718](https://jules.google.com/task/4907987034879649718) started by @hongymagic*