### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive credential leakage in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,8 @@
 **Vulnerability:** The `filterSensitiveFields` function in `src/providers/index.ts` used a manual recursive loop to drop sensitive keys, but it failed to recurse into arrays. If a configuration object contained an array with sensitive nested objects, those secrets would be leaked in debug logs.
 **Learning:** Manual object traversal for redaction is prone to edge cases (like arrays or circular references).
 **Prevention:** Use a custom replacer function with `JSON.stringify` to safely and completely redact sensitive fields across all nested structures.
+
+## 2026-03-12 - Secret Leakage of Common Web Authentication Tokens
+**Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
+**Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
+**Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.

--- a/src/sensitive.ts
+++ b/src/sensitive.ts
@@ -8,6 +8,10 @@ const SENSITIVE_KEY_PATTERNS = [
   "auth",
   "credential",
   "authorization",
+  "bearer",
+  "session",
+  "jwt",
+  "cookie",
 ];
 
 export function isSensitiveKey(key: string): boolean {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Common web authentication tokens (`bearer`, `session`, `jwt`, `cookie`) were missing from the sensitive keys list, leading to their plaintext exposure in debug and failure logs if present in configuration headers or payloads.
🎯 Impact: Attackers or unauthorized users could potentially extract valid authentication tokens from log files, leading to unauthorized access.
🔧 Fix: Expanded `SENSITIVE_KEY_PATTERNS` in `src/sensitive.ts` to include these common token names.
✅ Verification: Ran `bun run test` to verify changes, ensuring no regressions. Tests covering security string manipulation pass correctly.

---
*PR created automatically by Jules for task [11478949738618409907](https://jules.google.com/task/11478949738618409907) started by @hongymagic*