### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Credential Leakage via AI SDK Attached Header Properties in Error Logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
 **Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
 **Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.
+
+## 2026-03-13 - Secret Leakage in Error Diagnostics via AI SDK Attached Properties
+**Vulnerability:** In `src/logging.ts`, the `formatErrorDiagnostics` function omitted `requestBodyValues` and `responseBody`, but missed `requestHeaders` and `responseHeaders` attached to errors by the AI SDK. Because these full objects were serialized, they could expose raw credentials, tokens, or other sensitive header values if the error was logged in full.
+**Learning:** External libraries (like AI SDKs) often attach broad context objects (like entire request or response headers) to their error instances. Shallow key filters or standard redaction may fail or be bypassed by these large attached objects.
+**Prevention:** Explicitly omit full objects like `requestHeaders` and `responseHeaders` from error diagnostics by including them in `OMITTED_ERROR_PROPERTIES`.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -191,7 +191,12 @@ function formatSessionEntries(): string {
 
 // Error properties that may contain full request/response payloads (prompts, bodies).
 // These are omitted entirely from failure logs.
-const OMITTED_ERROR_PROPERTIES = new Set(["requestBodyValues", "responseBody"]);
+const OMITTED_ERROR_PROPERTIES = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "requestHeaders",
+  "responseHeaders",
+]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {
   const prefix = "  ".repeat(depth);

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -37,6 +37,22 @@ describe("formatErrorDiagnostics secret redaction", () => {
     expect(output).toContain("statusCode");
   });
 
+  it("omits requestHeaders and responseHeaders from error diagnostics", () => {
+    const error = new Error("Header error");
+    Object.assign(error, {
+      requestHeaders: { "x-api-key": "secret-api-key" },
+      responseHeaders: { "set-cookie": "session=123" },
+      statusCode: 400,
+    });
+
+    const output = formatErrorDiagnostics(error);
+    expect(output).not.toContain("secret-api-key");
+    expect(output).not.toContain("session=123");
+    expect(output).not.toContain("requestHeaders");
+    expect(output).not.toContain("responseHeaders");
+    expect(output).toContain("statusCode");
+  });
+
   it("redacts properties with sensitive key names", () => {
     const error = new Error("Auth failed");
     Object.assign(error, {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The error formatting logic in `src/logging.ts` omitted request and response bodies but failed to omit full `requestHeaders` and `responseHeaders` objects. External AI SDKs often attach these context objects to their thrown error instances. If these errors were logged, any sensitive authentication credentials, API keys, or session tokens present in those headers could be serialized in plaintext into the failure log.
🎯 **Impact:** If an unhandled error occurred that contained full header context, sensitive credentials (like `Authorization: Bearer <token>` or custom `x-api-key` headers) would be written to the local disk in a debug log. This could allow an attacker with local file access to exfiltrate valid credentials and impersonate the user or application.
🔧 **Fix:** Added `requestHeaders` and `responseHeaders` to the `OMITTED_ERROR_PROPERTIES` Set in `src/logging.ts`. This ensures these large attached context objects are entirely stripped from the error before it undergoes diagnostic formatting and serialization, preventing credential leakage.
✅ **Verification:** Added a unit test in `tests/logging.test.ts` to construct a mock error object containing `requestHeaders` and `responseHeaders`. The test verifies that `formatErrorDiagnostics` correctly strips these objects and they do not appear in the final output string. Run `bun run test` to verify.

---
*PR created automatically by Jules for task [8522971824994698595](https://jules.google.com/task/8522971824994698595) started by @hongymagic*