### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix credential leakage in error logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
 **Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
 **Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.
+
+## 2026-03-13 - API Credential Leakage in AI SDK Error Logs
+**Vulnerability:** When API requests to AI providers failed, the resulting error logs often included the full original Error object from the AI SDK. Some AI SDKs attach `requestHeaders` and `responseHeaders` to their error objects for debugging purposes. These headers contain highly sensitive authentication credentials (like `Authorization: Bearer <token>` or `x-api-key`), which bypassed the basic top-level sensitive key filtering in the logging utility because they were nested inside these specific objects, leading to plaintext credential leakage in the error logs.
+**Learning:** Default object dumping mechanisms and shallow filtering are insufficient for complex error objects originating from external libraries. We must anticipate that HTTP client libraries and SDKs will attach request/response metadata to errors.
+**Prevention:** Explicitly omit known metadata properties (like `requestHeaders` and `responseHeaders`) from error objects before logging, rather than relying solely on key-name redaction logic that may miss nested credentials.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -191,7 +191,12 @@ function formatSessionEntries(): string {
 
 // Error properties that may contain full request/response payloads (prompts, bodies).
 // These are omitted entirely from failure logs.
-const OMITTED_ERROR_PROPERTIES = new Set(["requestBodyValues", "responseBody"]);
+const OMITTED_ERROR_PROPERTIES = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "requestHeaders",
+  "responseHeaders",
+]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {
   const prefix = "  ".repeat(depth);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When API requests to AI providers fail, AI SDKs often attach `requestHeaders` and `responseHeaders` to their error objects for debugging purposes. These headers contain highly sensitive authentication credentials (like `Authorization: Bearer <token>` or `x-api-key`), which bypassed the basic sensitive key filtering in the logging utility because they were not explicitly omitted, leading to plaintext credential leakage in the error logs.
🎯 Impact: Anyone with read access to the application logs or the specific `q` failure logs directory could potentially retrieve plain-text API keys or authorization tokens, leading to an account takeover, data exfiltration, or financial loss due to unauthorized API usage.
🔧 Fix: Explicitly added `"requestHeaders"` and `"responseHeaders"` to the `OMITTED_ERROR_PROPERTIES` set in `src/logging.ts`. This ensures that these properties, which are known to frequently contain sensitive credentials, are entirely excluded from any error dumps written to failure logs.
✅ Verification: Ensure the test suite passes via `bun run test`. Specifically, the error logging logic in `tests/logging.test.ts` should confirm no unexpected changes to formatting, while the newly omitted fields are simply skipped during serialization.

---
*PR created automatically by Jules for task [16918716395025277348](https://jules.google.com/task/16918716395025277348) started by @hongymagic*