### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Credential Leakage via Error Properties

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,7 @@
 **Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
 **Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
 **Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.
+## 2025-02-14 - Leakage of Credentials via Error Properties
+**Vulnerability:** AI SDKs may attach objects like `requestHeaders` and `responseHeaders` to error instances, which bypasses shallow sensitive key checks and leads to full credential leakage in failure logs.
+**Learning:** Checking error properties dynamically with a shallow filter is insufficient when third-party SDKs nest sensitive payloads within complex structures.
+**Prevention:** Explicitly omit top-level error properties known to carry entire request/response contexts, such as `requestHeaders` and `responseHeaders`, before serialization.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -189,9 +189,15 @@ function formatSessionEntries(): string {
     .join("\n");
 }
 
-// Error properties that may contain full request/response payloads (prompts, bodies).
+// Error properties that may contain full request/response payloads (prompts, bodies)
+// or sensitive information like authorization tokens.
 // These are omitted entirely from failure logs.
-const OMITTED_ERROR_PROPERTIES = new Set(["requestBodyValues", "responseBody"]);
+const OMITTED_ERROR_PROPERTIES = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "requestHeaders",
+  "responseHeaders",
+]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {
   const prefix = "  ".repeat(depth);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: AI SDKs attach objects like `requestHeaders` and `responseHeaders` to error instances, which bypasses shallow sensitive key checks and leads to full credential leakage in failure logs.
🎯 Impact: Attackers who gain access to the failure logs could extract valid authentication tokens.
🔧 Fix: Added `"requestHeaders"` and `"responseHeaders"` to `OMITTED_ERROR_PROPERTIES` in `src/logging.ts`.
✅ Verification: Ran test suite and manually reviewed logging redaction strategy.

---
*PR created automatically by Jules for task [6479504038645587171](https://jules.google.com/task/6479504038645587171) started by @hongymagic*