### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix credential leakage in failure logs via AI SDK error objects

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
 **Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
 **Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.
+
+## 2026-07-20 - Secret Leakage in Failure Logs via AI SDK Error Objects
+**Vulnerability:** AI SDKs frequently attach full request and response HTTP objects (including `requestHeaders` and `responseHeaders`) to error instances when requests fail. The `formatErrorDiagnostics` function failed to omit these properties, meaning sensitive HTTP headers (like standard and custom API keys) would be logged to disk in plaintext if a request failed.
+**Learning:** Security token redaction checks that only match shallow keys (like `headers` or specific token names) can be bypassed if full nested HTTP request/response objects are attached directly as top-level properties on an Error object.
+**Prevention:** Explicitly omit full request and response payload properties (like `requestHeaders` and `responseHeaders`) from error diagnostic logs entirely, rather than attempting to redact their contents.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -191,7 +191,12 @@ function formatSessionEntries(): string {
 
 // Error properties that may contain full request/response payloads (prompts, bodies).
 // These are omitted entirely from failure logs.
-const OMITTED_ERROR_PROPERTIES = new Set(["requestBodyValues", "responseBody"]);
+const OMITTED_ERROR_PROPERTIES = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "requestHeaders",
+  "responseHeaders",
+]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {
   const prefix = "  ".repeat(depth);

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -37,6 +37,23 @@ describe("formatErrorDiagnostics secret redaction", () => {
     expect(output).toContain("statusCode");
   });
 
+  it("omits requestHeaders and responseHeaders from error diagnostics", () => {
+    const error = new Error("API error");
+    Object.assign(error, {
+      requestHeaders: { "x-api-key": "secret-key" },
+      responseHeaders: { "x-internal-id": "internal-val" },
+      statusCode: 403,
+    });
+
+    const output = formatErrorDiagnostics(error);
+    expect(output).not.toContain("secret-key");
+    expect(output).not.toContain("internal-val");
+    expect(output).not.toContain("requestHeaders");
+    expect(output).not.toContain("responseHeaders");
+    expect(output).toContain("statusCode");
+    expect(output).toContain("403");
+  });
+
   it("redacts properties with sensitive key names", () => {
     const error = new Error("Auth failed");
     Object.assign(error, {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: AI SDKs frequently attach full request and response HTTP objects (including `requestHeaders` and `responseHeaders`) to error instances when requests fail. The `formatErrorDiagnostics` function failed to omit these properties, meaning sensitive HTTP headers (like standard and custom API keys) would be logged to disk in plaintext if a request failed.
🎯 Impact: Sensitive credentials (like API keys) could be leaked in failure logs.
🔧 Fix: Explicitly omit full request and response payload properties (like `requestHeaders` and `responseHeaders`) from error diagnostic logs entirely, rather than attempting to redact their contents. Added test to verify this behavior.
✅ Verification: Ran `bun run test` to verify changes, which all pass.

---
*PR created automatically by Jules for task [9234377683465974641](https://jules.google.com/task/9234377683465974641) started by @hongymagic*