### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix credential leakage in error logs via request/response headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
 **Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
 **Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.
+
+## 2026-07-21 - Credential Leakage in Error Logs via AI SDK Attached Headers
+**Vulnerability:** AI SDKs may attach full `requestHeaders` and `responseHeaders` objects to error instances. Since these properties weren't in `OMITTED_ERROR_PROPERTIES`, they were logged. While basic shallow redaction caught explicitly named sensitive keys (like `Authorization`), unrecognized or subtly named header keys within these request/response header collections might still bypass redaction, leaking credentials or sensitive data into debug/failure logs.
+**Learning:** Always aggressively exclude entire raw request/response metadata objects (like headers, bodies) from logs by default when relying on external SDKs that attach these to error objects.
+**Prevention:** Add `requestHeaders` and `responseHeaders` to `OMITTED_ERROR_PROPERTIES` in `src/logging.ts` to explicitly block these properties entirely, rather than relying on deep key-based redaction of unknown external data structures.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -191,7 +191,12 @@ function formatSessionEntries(): string {
 
 // Error properties that may contain full request/response payloads (prompts, bodies).
 // These are omitted entirely from failure logs.
-const OMITTED_ERROR_PROPERTIES = new Set(["requestBodyValues", "responseBody"]);
+const OMITTED_ERROR_PROPERTIES = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "requestHeaders",
+  "responseHeaders",
+]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {
   const prefix = "  ".repeat(depth);

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -40,8 +40,14 @@ describe("formatErrorDiagnostics secret redaction", () => {
   it("omits requestHeaders and responseHeaders from error diagnostics", () => {
     const error = new Error("Headers error");
     Object.assign(error, {
-      requestHeaders: { "x-api-key": "secret-request-key", "Authorization": "Bearer token123" },
-      responseHeaders: { "set-cookie": "session=secret-cookie", "x-sensitive-response": "val" },
+      requestHeaders: {
+        "x-api-key": "secret-request-key",
+        Authorization: "Bearer token123",
+      },
+      responseHeaders: {
+        "set-cookie": "session=secret-cookie",
+        "x-sensitive-response": "val",
+      },
       statusCode: 403,
     });
 

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -37,6 +37,24 @@ describe("formatErrorDiagnostics secret redaction", () => {
     expect(output).toContain("statusCode");
   });
 
+  it("omits requestHeaders and responseHeaders from error diagnostics", () => {
+    const error = new Error("Headers error");
+    Object.assign(error, {
+      requestHeaders: { "x-api-key": "secret-request-key", "Authorization": "Bearer token123" },
+      responseHeaders: { "set-cookie": "session=secret-cookie", "x-sensitive-response": "val" },
+      statusCode: 403,
+    });
+
+    const output = formatErrorDiagnostics(error);
+    expect(output).not.toContain("secret-request-key");
+    expect(output).not.toContain("token123");
+    expect(output).not.toContain("secret-cookie");
+    expect(output).not.toContain("requestHeaders");
+    expect(output).not.toContain("responseHeaders");
+    expect(output).toContain("statusCode");
+    expect(output).toContain("403");
+  });
+
   it("redacts properties with sensitive key names", () => {
     const error = new Error("Auth failed");
     Object.assign(error, {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: AI SDKs attach raw `requestHeaders` and `responseHeaders` objects to error instances. While basic shallow key redaction (e.g. for `Authorization`) worked, unrecognized or subtly named header keys within these collections could bypass redaction and leak credentials/sensitive tokens into plain text debug and failure logs.
🎯 **Impact**: An attacker who can trigger a request failure while debugging is enabled, or who can access local error logs, could extract unredacted sensitive tokens or credentials from the headers of failing AI requests.
🔧 **Fix**: Added `requestHeaders` and `responseHeaders` to the `OMITTED_ERROR_PROPERTIES` allowlist in `src/logging.ts` to ensure these properties are fully dropped before serialization and logging, rendering deep key inspection unnecessary for these specific objects.
✅ **Verification**: Run `bun run test` to verify unit tests (`tests/logging.test.ts`) assert that `requestHeaders` and `responseHeaders` are no longer present in error logs.

---
*PR created automatically by Jules for task [17492155626223658411](https://jules.google.com/task/17492155626223658411) started by @hongymagic*