### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix sensitive header leakage in error logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
 **Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
 **Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.
+
+## 2024-05-24 - Prevent Header Leakage in Error Logs
+**Vulnerability:** Application error logs were at risk of exposing sensitive data via HTTP request and response headers attached to errors by the AI SDK.
+**Learning:** `OMITTED_ERROR_PROPERTIES` did not initially include `requestHeaders` and `responseHeaders`, which bypass shallow sensitive key checks since they are often nested objects or arrays attached to error instances by modern AI SDKs.
+**Prevention:** Explicitly exclude `requestHeaders` and `responseHeaders` from failure logs by adding them to `OMITTED_ERROR_PROPERTIES`.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -191,7 +191,12 @@ function formatSessionEntries(): string {
 
 // Error properties that may contain full request/response payloads (prompts, bodies).
 // These are omitted entirely from failure logs.
-const OMITTED_ERROR_PROPERTIES = new Set(["requestBodyValues", "responseBody"]);
+const OMITTED_ERROR_PROPERTIES = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "requestHeaders",
+  "responseHeaders",
+]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {
   const prefix = "  ".repeat(depth);


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** AI SDKs often attach full HTTP request and response header objects to error instances. Without explicitly omitting these, sensitive headers (like `Authorization`, API keys, or cookies) could bypass shallow sensitive key checks and be written to local failure logs.
🎯 **Impact:** Exposing sensitive credentials in local log files could allow unauthorized local users or malicious processes with access to the log directory to extract secrets.
🔧 **Fix:** Explicitly added `requestHeaders` and `responseHeaders` to the `OMITTED_ERROR_PROPERTIES` set in `src/logging.ts`, completely redacting them from failure log files.
✅ **Verification:** Verified by running tests. The properties will no longer be enumerated when `formatUnknownValue` processes an error instance.

---
*PR created automatically by Jules for task [11117847176952847826](https://jules.google.com/task/11117847176952847826) started by @hongymagic*