### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix credential leak via AI SDK error headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
 **Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
 **Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.
+
+## 2026-07-23 - Secret Leakage via AI SDK Error Request/Response Headers
+**Vulnerability:** AI SDK error instances frequently included `requestHeaders` and `responseHeaders` properties which contained sensitive tokens (like `Authorization` headers). Since these objects bypassed shallow sensitive key checks by being nested within the un-omitted header objects, credentials could leak in failure logs.
+**Learning:** Error diagnostic functions that dump object properties must maintain a robust list of fully excluded properties for known SDK-attached context (like headers and bodies) to prevent leakage of credentials in untrusted structures attached to error objects.
+**Prevention:** Explicitly include `requestHeaders` and `responseHeaders` in the `OMITTED_ERROR_PROPERTIES` list to ensure they are dropped entirely from error diagnostics and failure logs.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -191,7 +191,12 @@ function formatSessionEntries(): string {
 
 // Error properties that may contain full request/response payloads (prompts, bodies).
 // These are omitted entirely from failure logs.
-const OMITTED_ERROR_PROPERTIES = new Set(["requestBodyValues", "responseBody"]);
+const OMITTED_ERROR_PROPERTIES = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "requestHeaders",
+  "responseHeaders",
+]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {
   const prefix = "  ".repeat(depth);

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -37,6 +37,23 @@ describe("formatErrorDiagnostics secret redaction", () => {
     expect(output).toContain("statusCode");
   });
 
+  it("omits requestHeaders and responseHeaders from error diagnostics", () => {
+    const error = new Error("API error");
+    Object.assign(error, {
+      requestHeaders: { Authorization: "Bearer leak-me" },
+      responseHeaders: { "set-cookie": "session=secret" },
+      statusCode: 401,
+    });
+
+    const output = formatErrorDiagnostics(error);
+    expect(output).not.toContain("leak-me");
+    expect(output).not.toContain("requestHeaders");
+    expect(output).not.toContain("session=secret");
+    expect(output).not.toContain("responseHeaders");
+    expect(output).toContain("statusCode");
+    expect(output).toContain("401");
+  });
+
   it("redacts properties with sensitive key names", () => {
     const error = new Error("Auth failed");
     Object.assign(error, {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: When AI SDKs encounter an error (e.g. rate limit, 500, etc.), they frequently attach request/response context to the thrown error instance. This context includes full request/response headers inside `requestHeaders` and `responseHeaders` properties. Since the error serializer (`formatErrorDiagnostics`) only checked shallow property names against sensitive keywords, it allowed these nested header objects to print out entirely. Any authentication token sent in the headers (like `Authorization: Bearer <token>`) could leak in cleartext into local failure logs.
🎯 Impact: Attackers or malicious users on the same machine could inspect the `~/.local/state/q/errors` folder (if permissions somehow allowed it, or if they tricked the user into sending them the log file for debugging) and steal upstream AI provider tokens or internal gateway tokens.
🔧 Fix: Explicitly included `requestHeaders` and `responseHeaders` in `OMITTED_ERROR_PROPERTIES` inside `src/logging.ts`. This causes the error diagnostic formatter to completely skip these properties, ensuring no nested tokens leak. Added a unit test.
✅ Verification: Tested via `bun run test tests/logging.test.ts` where a simulated error with a `requestHeaders` object verifies the `Authorization` header isn't printed.

---
*PR created automatically by Jules for task [10791015437753673477](https://jules.google.com/task/10791015437753673477) started by @hongymagic*