### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix credential leakage in error logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
 **Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
 **Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.
+
+## 2026-07-26 - Credential Leakage via Attached SDK Request Headers
+**Vulnerability:** The logging functionality sanitized properties like `requestBodyValues` and `responseBody` by omitting them from error logs. However, it failed to omit `requestHeaders` and `responseHeaders`, which can be attached to Error objects by AI SDKs. This omission could lead to leakage of API keys, Authorization tokens, and Cookies in plain text inside failure logs.
+**Learning:** Hardcoded redaction patterns must continually evolve. The AI SDK ecosystem frequently updates which properties it attaches to error objects for debugging purposes. Properties containing headers must be completely omitted from logging unless their individual key-value pairs are run through the deep redaction system.
+**Prevention:** Always maintain a comprehensive list of known properties that contain credentials (like `requestHeaders` and `responseHeaders`) in the omit list for error diagnostics logging.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -191,7 +191,12 @@ function formatSessionEntries(): string {
 
 // Error properties that may contain full request/response payloads (prompts, bodies).
 // These are omitted entirely from failure logs.
-const OMITTED_ERROR_PROPERTIES = new Set(["requestBodyValues", "responseBody"]);
+const OMITTED_ERROR_PROPERTIES = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "requestHeaders",
+  "responseHeaders",
+]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {
   const prefix = "  ".repeat(depth);

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -37,6 +37,23 @@ describe("formatErrorDiagnostics secret redaction", () => {
     expect(output).toContain("statusCode");
   });
 
+  it("omits requestHeaders and responseHeaders from error diagnostics", () => {
+    const error = new Error("Network error");
+    Object.assign(error, {
+      requestHeaders: { "x-api-key": "secret-key-123" },
+      responseHeaders: { "set-cookie": "session=secret-session" },
+      statusCode: 502,
+    });
+
+    const output = formatErrorDiagnostics(error);
+    expect(output).not.toContain("secret-key-123");
+    expect(output).not.toContain("requestHeaders");
+    expect(output).not.toContain("secret-session");
+    expect(output).not.toContain("responseHeaders");
+    expect(output).toContain("statusCode");
+    expect(output).toContain("502");
+  });
+
   it("redacts properties with sensitive key names", () => {
     const error = new Error("Auth failed");
     Object.assign(error, {


### PR DESCRIPTION
🚨 **Severity: CRITICAL**

💡 **Vulnerability:** The error diagnostic logging failed to omit `requestHeaders` and `responseHeaders`. AI SDKs can sometimes attach these objects to standard Error instances when HTTP requests fail.

🎯 **Impact:** If an AI SDK fails to connect or authenticates poorly, it may attach the full request/response headers to the error object. Since these headers were not omitted, sensitive data like `Authorization` tokens, `x-api-key`, and `Set-Cookie` could be written in plain text to the local diagnostic log file, leading to a local credential leak.

🔧 **Fix:** Added `"requestHeaders"` and `"responseHeaders"` to the `OMITTED_ERROR_PROPERTIES` set in `src/logging.ts`, ensuring that these properties are entirely dropped from the error object before it is serialized and written to the log file.

✅ **Verification:** Verified by running `bun run test` locally. A new unit test explicitly ensures that `requestHeaders` and `responseHeaders` attached to an error object are safely omitted from the diagnostics output.

---
*PR created automatically by Jules for task [3375370040008096744](https://jules.google.com/task/3375370040008096744) started by @hongymagic*