### PR TITLE
🛡️ Sentinel: [HIGH] Fix credential leakage in error logs via request/response headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
 **Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
 **Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.
+
+## 2026-07-28 - Secret Leakage via SDK Attached Request/Response Headers
+**Vulnerability:** The AI SDKs frequently attach full request and response objects (including `requestHeaders` and `responseHeaders`) to error instances. These headers often contain raw API keys and authentication tokens. The previous log redactor omitted `requestBodyValues` and `responseBody`, but missed the headers, exposing credentials in failure logs.
+**Learning:** Third-party SDK error objects are notoriously noisy and can bypass shallow sensitive key checks by wrapping secrets in nested structures or standard property names like `requestHeaders`.
+**Prevention:** Explicitly omit network metadata objects (like `requestHeaders` and `responseHeaders`) entirely from error diagnostic logs to prevent credential leakage.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -191,7 +191,12 @@ function formatSessionEntries(): string {
 
 // Error properties that may contain full request/response payloads (prompts, bodies).
 // These are omitted entirely from failure logs.
-const OMITTED_ERROR_PROPERTIES = new Set(["requestBodyValues", "responseBody"]);
+const OMITTED_ERROR_PROPERTIES = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "requestHeaders",
+  "responseHeaders",
+]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {
   const prefix = "  ".repeat(depth);

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -37,6 +37,23 @@ describe("formatErrorDiagnostics secret redaction", () => {
     expect(output).toContain("statusCode");
   });
 
+  it("omits requestHeaders and responseHeaders from error diagnostics", () => {
+    const error = new Error("API error");
+    Object.assign(error, {
+      requestHeaders: { "x-api-key": "secret-api-key" },
+      responseHeaders: { "set-cookie": "session=secret-session-token" },
+      statusCode: 403,
+    });
+
+    const output = formatErrorDiagnostics(error);
+    expect(output).not.toContain("secret-api-key");
+    expect(output).not.toContain("secret-session-token");
+    expect(output).not.toContain("requestHeaders");
+    expect(output).not.toContain("responseHeaders");
+    expect(output).toContain("statusCode");
+    expect(output).toContain("403");
+  });
+
   it("redacts properties with sensitive key names", () => {
     const error = new Error("Auth failed");
     Object.assign(error, {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: AI SDKs often attach full `requestHeaders` and `responseHeaders` to error instances when network requests fail. These headers typically contain raw API keys, OAuth tokens, and session cookies. The `formatErrorDiagnostics` function was logging these headers in plaintext, bypassing shallow redaction checks.
🎯 Impact: Failure logs containing sensitive credentials could be exposed to unauthorized users or systems.
🔧 Fix: Explicitly added `"requestHeaders"` and `"responseHeaders"` to the `OMITTED_ERROR_PROPERTIES` set in `src/logging.ts` to ensure they are entirely stripped from error diagnostic logs.
✅ Verification: Ran `bun run test tests/logging.test.ts` to ensure the new tests verify the omission of these headers.

---
*PR created automatically by Jules for task [11376576893153736752](https://jules.google.com/task/11376576893153736752) started by @hongymagic*