### PR TITLE
🛡️ Sentinel: Prevent credential leakage in failure logs via AI SDK error properties

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
 **Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
 **Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.
+
+## 2026-08-05 - Secret Leakage in Debug Logs via Request/Response Headers Object
+**Vulnerability:** The AI SDK occasionally attaches HTTP header objects (e.g. `requestHeaders`, `responseHeaders`) to error instances during failures. Since the logging utility only omitted `requestBodyValues` and `responseBody`, credentials included within these headers (like `Authorization` or `set-cookie`) could be inadvertently logged when errors were formatted for diagnostics.
+**Learning:** SDK errors can contain complete network request/response context payloads, providing a backdoor vector for secrets to enter logs if they are not specifically ignored or redacted.
+**Prevention:** Explicitly omit network header objects (`requestHeaders`, `responseHeaders`) alongside request bodies when sanitizing and formatting error objects.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -191,7 +191,12 @@ function formatSessionEntries(): string {
 
 // Error properties that may contain full request/response payloads (prompts, bodies).
 // These are omitted entirely from failure logs.
-const OMITTED_ERROR_PROPERTIES = new Set(["requestBodyValues", "responseBody"]);
+const OMITTED_ERROR_PROPERTIES = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "requestHeaders",
+  "responseHeaders",
+]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {
   const prefix = "  ".repeat(depth);

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -37,6 +37,23 @@ describe("formatErrorDiagnostics secret redaction", () => {
     expect(output).toContain("statusCode");
   });
 
+  it("omits requestHeaders and responseHeaders from error diagnostics", () => {
+    const error = new Error("Network error");
+    Object.assign(error, {
+      requestHeaders: { "x-api-key": "secret-key" },
+      responseHeaders: { "set-cookie": "session=secret" },
+      statusCode: 502,
+    });
+
+    const output = formatErrorDiagnostics(error);
+    expect(output).not.toContain("secret-key");
+    expect(output).not.toContain("requestHeaders");
+    expect(output).not.toContain("session=secret");
+    expect(output).not.toContain("responseHeaders");
+    expect(output).toContain("statusCode");
+    expect(output).toContain("502");
+  });
+
   it("redacts properties with sensitive key names", () => {
     const error = new Error("Auth failed");
     Object.assign(error, {


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: AI SDK errors can attach `requestHeaders` and `responseHeaders` containing plaintext secrets like `Authorization` headers or session cookies. Since these were not explicitly ignored, they could leak into the failure and debug diagnostic logs.
🎯 **Impact**: If a user uploads or shares their failure log (e.g. for debugging), they could inadvertently leak their provider API keys or auth tokens to third parties.
🔧 **Fix**: Added `requestHeaders` and `responseHeaders` to the `OMITTED_ERROR_PROPERTIES` constant in `src/logging.ts`.
✅ **Verification**: A new test case has been added in `tests/logging.test.ts` to verify `requestHeaders` and `responseHeaders` are stripped from `formatErrorDiagnostics()`.

---
*PR created automatically by Jules for task [11534969102749166641](https://jules.google.com/task/11534969102749166641) started by @hongymagic*