### PR TITLE
🛡️ Sentinel: [HIGH] Fix potential credential leakage via SDK error headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
 **Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
 **Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.
+
+## 2026-03-13 - AI SDK Credential Leakage in Error Logs via Request Headers
+**Vulnerability:** AI SDKs frequently attach full request and response payloads, including `requestHeaders` and `responseHeaders`, to error instances. If these headers contain custom or unusual authentication tokens that bypass heuristic sensitive key checks (like `isSensitiveKey`), they would leak in failure logs.
+**Learning:** We cannot rely solely on pattern-matching keys (like checking for "bearer" or "token") to protect credentials within large objects attached by third-party SDKs.
+**Prevention:** Entire objects that are known to carry high-risk context from third-party SDKs (like `requestHeaders` and `responseHeaders`, alongside `requestBodyValues` and `responseBody`) must be explicitly and completely omitted from being stringified into failure logs.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -191,7 +191,12 @@ function formatSessionEntries(): string {
 
 // Error properties that may contain full request/response payloads (prompts, bodies).
 // These are omitted entirely from failure logs.
-const OMITTED_ERROR_PROPERTIES = new Set(["requestBodyValues", "responseBody"]);
+const OMITTED_ERROR_PROPERTIES = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "requestHeaders",
+  "responseHeaders",
+]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {
   const prefix = "  ".repeat(depth);

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -37,6 +37,23 @@ describe("formatErrorDiagnostics secret redaction", () => {
     expect(output).toContain("statusCode");
   });
 
+  it("omits requestHeaders and responseHeaders from error diagnostics", () => {
+    const error = new Error("API error");
+    Object.assign(error, {
+      requestHeaders: { "x-custom-identity": "secret-identity" },
+      responseHeaders: { "set-cookie": "secret-cookie" },
+      statusCode: 401,
+    });
+
+    const output = formatErrorDiagnostics(error);
+    expect(output).not.toContain("secret-identity");
+    expect(output).not.toContain("secret-cookie");
+    expect(output).not.toContain("requestHeaders");
+    expect(output).not.toContain("responseHeaders");
+    expect(output).toContain("statusCode");
+    expect(output).toContain("401");
+  });
+
   it("redacts properties with sensitive key names", () => {
     const error = new Error("Auth failed");
     Object.assign(error, {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** AI SDKs may attach full request and response payloads to error instances, including `requestHeaders` and `responseHeaders`. If these headers contain sensitive credentials (like custom API tokens, cookies, etc.) that aren't caught by the generic heuristic pattern matcher `isSensitiveKey`, they will be logged in plaintext inside the failure logs.
🎯 **Impact:** Potential leakage of sensitive identity or API credentials to local disk via failure logs.
🔧 **Fix:** Added `requestHeaders` and `responseHeaders` to the `OMITTED_ERROR_PROPERTIES` set in `src/logging.ts` so they are completely excluded from stringification in error diagnostics, preventing any chance of credential leakage from these objects.
✅ **Verification:** Added test cases in `tests/logging.test.ts` to verify that `requestHeaders` and `responseHeaders` are omitted from the output of `formatErrorDiagnostics`.

---
*PR created automatically by Jules for task [8859757514905352069](https://jules.google.com/task/8859757514905352069) started by @hongymagic*