### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix credential leakage via requestHeaders in error logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The `isSensitiveKey` function missed common credential identifiers like `bearer`, `session`, `jwt`, and `cookie`. These are frequently used in headers and objects, leading to plaintext exposure in logs.
 **Learning:** Hardcoded sensitive key patterns need to account for diverse authentication mechanisms, not just generic "key" or "secret" terms.
 **Prevention:** Include a comprehensive set of common credential token names (`bearer`, `session`, `jwt`, `cookie`) in the `SENSITIVE_KEY_PATTERNS` array.
+
+## 2026-03-14 - Secret Leakage of Headers in Error Diagnostics
+**Vulnerability:** AI SDKs and underlying network libraries frequently attach `requestHeaders` and `responseHeaders` to error objects. These objects bypass shallow sensitive key checks when they are stringified, potentially leaking credentials (like `Authorization` headers or cookies) in debug logs.
+**Learning:** We cannot assume that all sensitive fields will be top-level keys matching predefined patterns. Entire objects containing headers or request/response payloads should be entirely omitted from logs to prevent inadvertent leakage.
+**Prevention:** Explicitly omit `requestHeaders` and `responseHeaders` from error diagnostics by adding them to `OMITTED_ERROR_PROPERTIES`.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -195,7 +195,7 @@ const OMITTED_ERROR_PROPERTIES = new Set([
   "requestBodyValues",
   "responseBody",
   "requestHeaders",
-  "responseHeaders"
+  "responseHeaders",
 ]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -191,7 +191,12 @@ function formatSessionEntries(): string {
 
 // Error properties that may contain full request/response payloads (prompts, bodies).
 // These are omitted entirely from failure logs.
-const OMITTED_ERROR_PROPERTIES = new Set(["requestBodyValues", "responseBody"]);
+const OMITTED_ERROR_PROPERTIES = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "requestHeaders",
+  "responseHeaders"
+]);
 
 function formatUnknownValue(value: unknown, depth = 0): string {
   const prefix = "  ".repeat(depth);

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -37,6 +37,23 @@ describe("formatErrorDiagnostics secret redaction", () => {
     expect(output).toContain("statusCode");
   });
 
+  it("omits requestHeaders and responseHeaders from error diagnostics", () => {
+    const error = new Error("API error");
+    Object.assign(error, {
+      requestHeaders: { "authorization": "Bearer secret-token", "x-api-key": "secret-key" },
+      responseHeaders: { "set-cookie": "session=secret-session" },
+      statusCode: 403,
+    });
+
+    const output = formatErrorDiagnostics(error);
+    expect(output).not.toContain("secret-token");
+    expect(output).not.toContain("secret-key");
+    expect(output).not.toContain("secret-session");
+    expect(output).not.toContain("requestHeaders");
+    expect(output).not.toContain("responseHeaders");
+    expect(output).toContain("statusCode");
+  });
+
   it("redacts properties with sensitive key names", () => {
     const error = new Error("Auth failed");
     Object.assign(error, {

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -40,7 +40,10 @@ describe("formatErrorDiagnostics secret redaction", () => {
   it("omits requestHeaders and responseHeaders from error diagnostics", () => {
     const error = new Error("API error");
     Object.assign(error, {
-      requestHeaders: { "authorization": "Bearer secret-token", "x-api-key": "secret-key" },
+      requestHeaders: {
+        authorization: "Bearer secret-token",
+        "x-api-key": "secret-key",
+      },
       responseHeaders: { "set-cookie": "session=secret-session" },
       statusCode: 403,
     });


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** AI SDKs and underlying network libraries often attach `requestHeaders` and `responseHeaders` to error objects. Because `JSON.stringify` with a custom replacer may not fully redact nested structures if the structure bypasses the key checks (or if the entire object is logged verbatim), sensitive credentials like `Authorization` tokens, `x-api-key`, and cookies could be leaked in debug and failure logs.
🎯 **Impact:** If an API request fails, the generated failure log or debug output could expose sensitive user credentials and API keys in plain text, leading to credential theft if logs are shared or accessed inappropriately.
🔧 **Fix:** Explicitly added `requestHeaders` and `responseHeaders` to the `OMITTED_ERROR_PROPERTIES` set in `src/logging.ts`. This ensures that these entire objects are dropped from error diagnostics before any serialization occurs, guaranteeing that no headers are leaked.
✅ **Verification:** Added unit tests to `tests/logging.test.ts` to verify that `requestHeaders` and `responseHeaders` are completely omitted from the formatted error diagnostics output. Run `bun run test` to confirm.

---
*PR created automatically by Jules for task [6092099588777214528](https://jules.google.com/task/6092099588777214528) started by @hongymagic*